### PR TITLE
ci: build docker image and push to container registry

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -26,16 +26,16 @@ jobs:
     strategy:
       matrix:
         include:
-          - app_name: backend
+          - app_name: cmsabackend
             dockerfile: docker/Backend.Dockerfile
             password_secret: DOCKER_PASSWORD
-          - app_name: webapp
+          - app_name: cmsafrontend
             dockerfile: docker/Frontend.Dockerfile
             password_secret: DOCKER_PASSWORD
     uses: ./.github/workflows/build-docker.yml
     with:
-      registry: codegencontainerregpk.azurecr.io
-      username: codegencontainerregpk
+      registry: cmsacontainerreg.azurecr.io
+      username: cmsacontainerreg
       password_secret: ${{ matrix.password_secret }}
       app_name: ${{ matrix.app_name }}
       dockerfile: ${{ matrix.dockerfile }}

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -1,0 +1,41 @@
+name: Build Docker and Optional Push
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+      - demo
+  pull_request:
+    branches:
+      - main
+      - dev
+      - demo
+    types:
+      - opened
+      - ready_for_review
+      - reopened
+      - synchronize
+  merge_group:
+  workflow_dispatch:
+
+jobs:
+  docker-build:
+    strategy:
+      matrix:
+        include:
+          - app_name: backend
+            dockerfile: docker/Backend.Dockerfile
+            password_secret: DOCKER_PASSWORD
+          - app_name: webapp
+            dockerfile: docker/Frontend.Dockerfile
+            password_secret: DOCKER_PASSWORD
+    uses: ./.github/workflows/build-docker.yml
+    with:
+      registry: codegencontainerregpk.azurecr.io
+      username: codegencontainerregpk
+      password_secret: ${{ matrix.password_secret }}
+      app_name: ${{ matrix.app_name }}
+      dockerfile: ${{ matrix.dockerfile }}
+      push: ${{ github.event_name == 'push' || github.base_ref == 'main' || github.base_ref == 'dev' || github.base_ref == 'demo' }}
+    secrets: inherit

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -6,11 +6,13 @@ on:
       - main
       - dev
       - demo
+      - hotfix
   pull_request:
     branches:
       - main
       - dev
       - demo
+      - hotfix
     types:
       - opened
       - ready_for_review
@@ -37,5 +39,5 @@ jobs:
       password_secret: ${{ matrix.password_secret }}
       app_name: ${{ matrix.app_name }}
       dockerfile: ${{ matrix.dockerfile }}
-      push: ${{ github.event_name == 'push' || github.base_ref == 'main' || github.base_ref == 'dev' || github.base_ref == 'demo' }}
+      push: ${{ github.event_name == 'push' || github.base_ref == 'main' || github.base_ref == 'dev' || github.base_ref == 'demo' || github.base_ref == 'hotfix' }}
     secrets: inherit

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,0 +1,76 @@
+name: Reusable Docker build and push workflow
+
+on:
+  workflow_call:
+    inputs:
+      registry:
+        required: true
+        type: string
+      username:
+        required: true
+        type: string
+      password_secret:
+        required: true
+        type: string
+      app_name:
+        required: true
+        type: string
+      dockerfile:
+        required: true
+        type: string
+      push:
+        required: true
+        type: boolean
+    secrets:
+      DOCKER_PASSWORD:
+        required: true
+
+jobs:
+  docker-build:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Docker Login
+      if: ${{ inputs.push }}
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ inputs.registry }}
+        username: ${{ inputs.username }}
+        password: ${{ secrets[inputs.password_secret] }}
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Get current date
+      id: date
+      run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+
+    - name: Determine Tag Name Based on Branch
+      id: determine_tag
+      run: |
+        if [[ "${{ github.base_ref }}" == "main" ]]; then
+          echo "tagname=latest" >> $GITHUB_OUTPUT
+        elif [[ "${{ github.base_ref }}" == "dev" ]]; then
+          echo "tagname=dev" >> $GITHUB_OUTPUT
+        elif [[ "${{ github.base_ref }}" == "demo" ]]; then
+          echo "tagname=demo" >> $GITHUB_OUTPUT
+        elif [[ "${{ github.base_ref }}" == "dependabotchanges" ]]; then
+          echo "tagname=dependabotchanges" >> $GITHUB_OUTPUT
+        else
+          echo "tagname=default" >> $GITHUB_OUTPUT
+        fi
+
+
+    - name: Build Docker Image and optionally push
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: ${{ inputs.dockerfile }}
+        push: ${{ inputs.push }}
+        cache-from: type=registry,ref=${{ inputs.registry }}/${{ inputs.app_name}}:${{ steps.determine_tag.outputs.tagname }}
+        tags: |
+          ${{ inputs.registry }}/${{ inputs.app_name}}:${{ steps.determine_tag.outputs.tagname }}
+          ${{ inputs.registry }}/${{ inputs.app_name}}:${{ steps.determine_tag.outputs.tagname }}_${{ steps.date.outputs.date }}_${{ github.run_number }}

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -57,6 +57,8 @@ jobs:
           echo "tagname=dev" >> $GITHUB_OUTPUT
         elif [[ "${{ github.base_ref }}" == "demo" ]]; then
           echo "tagname=demo" >> $GITHUB_OUTPUT
+        elif [[ "${{ github.base_ref }}" == "hotfix" ]]; then
+          echo "tagname=hotfix" >> $GITHUB_OUTPUT
         elif [[ "${{ github.base_ref }}" == "dependabotchanges" ]]; then
           echo "tagname=dependabotchanges" >> $GITHUB_OUTPUT
         else


### PR DESCRIPTION
This pull request introduces a new workflow for building and optionally pushing Docker images. The changes include the creation of two new workflow files: one for triggering the Docker build process and another reusable workflow for the actual build and push operations.

### New Workflows for Docker Build and Push

* [`.github/workflows/build-docker-images.yml`](diffhunk://#diff-2817fc9ec6443e19233164eefa86576a0972ce81bcf0ec4a04f96d6119db038eR1-R41): This workflow is designed to trigger Docker builds on specific branches (`main`, `dev`, `demo`) and during specific pull request events (`opened`, `ready_for_review`, `reopened`, `synchronize`). It uses a matrix strategy to handle different applications (`backend`, `webapp`) and their respective Dockerfiles.

* [`.github/workflows/build-docker.yml`](diffhunk://#diff-1d203d2dfb96ccf94b5e0961c7954e3bde73b4539ade27ccc301613e368b944fR1-R76): This reusable workflow handles the actual Docker build and push process. It includes steps for checking out the code, logging into Docker, setting up Docker Buildx, determining the tag name based on the branch, and building and optionally pushing the Docker image.