### PR TITLE
ci: build docker image and push to container registry

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -1,0 +1,43 @@
+name: Build Docker and Optional Push
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+      - demo
+      - hotfix
+  pull_request:
+    branches:
+      - main
+      - dev
+      - demo
+      - hotfix
+    types:
+      - opened
+      - ready_for_review
+      - reopened
+      - synchronize
+  merge_group:
+  workflow_dispatch:
+
+jobs:
+  docker-build:
+    strategy:
+      matrix:
+        include:
+          - app_name: cmsabackend
+            dockerfile: docker/Backend.Dockerfile
+            password_secret: DOCKER_PASSWORD
+          - app_name: cmsafrontend
+            dockerfile: docker/Frontend.Dockerfile
+            password_secret: DOCKER_PASSWORD
+    uses: ./.github/workflows/build-docker.yml
+    with:
+      registry: cmsacontainerreg.azurecr.io
+      username: cmsacontainerreg
+      password_secret: ${{ matrix.password_secret }}
+      app_name: ${{ matrix.app_name }}
+      dockerfile: ${{ matrix.dockerfile }}
+      push: ${{ github.event_name == 'push' || github.base_ref == 'main' || github.base_ref == 'dev' || github.base_ref == 'demo' || github.base_ref == 'hotfix' }}
+    secrets: inherit

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,0 +1,78 @@
+name: Reusable Docker build and push workflow
+
+on:
+  workflow_call:
+    inputs:
+      registry:
+        required: true
+        type: string
+      username:
+        required: true
+        type: string
+      password_secret:
+        required: true
+        type: string
+      app_name:
+        required: true
+        type: string
+      dockerfile:
+        required: true
+        type: string
+      push:
+        required: true
+        type: boolean
+    secrets:
+      DOCKER_PASSWORD:
+        required: true
+
+jobs:
+  docker-build:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Docker Login
+      if: ${{ inputs.push }}
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ inputs.registry }}
+        username: ${{ inputs.username }}
+        password: ${{ secrets[inputs.password_secret] }}
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Get current date
+      id: date
+      run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+
+    - name: Determine Tag Name Based on Branch
+      id: determine_tag
+      run: |
+        if [[ "${{ github.base_ref }}" == "main" ]]; then
+          echo "tagname=latest" >> $GITHUB_OUTPUT
+        elif [[ "${{ github.base_ref }}" == "dev" ]]; then
+          echo "tagname=dev" >> $GITHUB_OUTPUT
+        elif [[ "${{ github.base_ref }}" == "demo" ]]; then
+          echo "tagname=demo" >> $GITHUB_OUTPUT
+        elif [[ "${{ github.base_ref }}" == "hotfix" ]]; then
+          echo "tagname=hotfix" >> $GITHUB_OUTPUT
+        elif [[ "${{ github.base_ref }}" == "dependabotchanges" ]]; then
+          echo "tagname=dependabotchanges" >> $GITHUB_OUTPUT
+        else
+          echo "tagname=default" >> $GITHUB_OUTPUT
+        fi
+
+
+    - name: Build Docker Image and optionally push
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: ${{ inputs.dockerfile }}
+        push: ${{ inputs.push }}
+        cache-from: type=registry,ref=${{ inputs.registry }}/${{ inputs.app_name}}:${{ steps.determine_tag.outputs.tagname }}
+        tags: |
+          ${{ inputs.registry }}/${{ inputs.app_name}}:${{ steps.determine_tag.outputs.tagname }}
+          ${{ inputs.registry }}/${{ inputs.app_name}}:${{ steps.determine_tag.outputs.tagname }}_${{ steps.date.outputs.date }}_${{ github.run_number }}


### PR DESCRIPTION
This pull request introduces new workflows for building and optionally pushing Docker images. The changes are focused on setting up reusable and specific workflows for different branches and events.

### Workflow Additions:

* [`.github/workflows/build-docker-images.yml`](diffhunk://#diff-2817fc9ec6443e19233164eefa86576a0972ce81bcf0ec4a04f96d6119db038eR1-R43): Added a new workflow to build Docker images for different branches (`main`, `dev`, `demo`, `hotfix`) and events (push, pull request, merge group, workflow dispatch). This workflow uses a matrix strategy to handle multiple applications (`cmsabackend`, `cmsafrontend`).
* [`.github/workflows/build-docker.yml`](diffhunk://#diff-1d203d2dfb96ccf94b5e0961c7954e3bde73b4539ade27ccc301613e368b944fR1-R78): Added a reusable workflow for Docker build and push operations. This workflow is invoked by the main build workflow and handles Docker login, setting up Buildx, determining tag names based on branches, and building and optionally pushing Docker images.