### PR TITLE
fix: skip docker login on push

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -39,5 +39,5 @@ jobs:
       password_secret: ${{ matrix.password_secret }}
       app_name: ${{ matrix.app_name }}
       dockerfile: ${{ matrix.dockerfile }}
-      push: ${{ github.event_name == 'push' || github.base_ref == 'main' || github.base_ref == 'dev' || github.base_ref == 'demo' || github.base_ref == 'hotfix' }}
+      push: ${{ github.ref_name == 'main' || github.ref_name == 'dev' || github.ref_name == 'demo' || github.ref_name == 'hotfix' }}
     secrets: inherit

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -32,6 +32,9 @@ jobs:
 
     - name: Checkout
       uses: actions/checkout@v4
+    
+    - name: push debug
+      run: echo ${{ inputs.push }}
 
     - name: Docker Login
       if: ${{ inputs.push }}
@@ -51,15 +54,15 @@ jobs:
     - name: Determine Tag Name Based on Branch
       id: determine_tag
       run: |
-        if [[ "${{ github.base_ref }}" == "main" ]]; then
+        if [[ "${{ github.ref_name }}" == "main" ]]; then
           echo "tagname=latest" >> $GITHUB_OUTPUT
-        elif [[ "${{ github.base_ref }}" == "dev" ]]; then
+        elif [[ "${{ github.ref_name }}" == "dev" ]]; then
           echo "tagname=dev" >> $GITHUB_OUTPUT
-        elif [[ "${{ github.base_ref }}" == "demo" ]]; then
+        elif [[ "${{ github.ref_name }}" == "demo" ]]; then
           echo "tagname=demo" >> $GITHUB_OUTPUT
-        elif [[ "${{ github.base_ref }}" == "hotfix" ]]; then
+        elif [[ "${{ github.ref_name }}" == "hotfix" ]]; then
           echo "tagname=hotfix" >> $GITHUB_OUTPUT
-        elif [[ "${{ github.base_ref }}" == "dependabotchanges" ]]; then
+        elif [[ "${{ github.ref_name }}" == "dependabotchanges" ]]; then
           echo "tagname=dependabotchanges" >> $GITHUB_OUTPUT
         else
           echo "tagname=default" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -32,9 +32,6 @@ jobs:
 
     - name: Checkout
       uses: actions/checkout@v4
-    
-    - name: push debug
-      run: echo ${{ inputs.push }}
 
     - name: Docker Login
       if: ${{ inputs.push }}
@@ -62,8 +59,6 @@ jobs:
           echo "tagname=demo" >> $GITHUB_OUTPUT
         elif [[ "${{ github.ref_name }}" == "hotfix" ]]; then
           echo "tagname=hotfix" >> $GITHUB_OUTPUT
-        elif [[ "${{ github.ref_name }}" == "dependabotchanges" ]]; then
-          echo "tagname=dependabotchanges" >> $GITHUB_OUTPUT
         else
           echo "tagname=default" >> $GITHUB_OUTPUT
         fi


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflows to use `github.ref_name` instead of `github.base_ref` for determining branch conditions. This change ensures more accurate branch detection in various workflow steps.

Changes to GitHub Actions workflows:

* [`.github/workflows/build-docker-images.yml`](diffhunk://#diff-2817fc9ec6443e19233164eefa86576a0972ce81bcf0ec4a04f96d6119db038eL42-R42): Updated the `push` condition to use `github.ref_name` instead of `github.base_ref`.
* [`.github/workflows/build-docker.yml`](diffhunk://#diff-1d203d2dfb96ccf94b5e0961c7954e3bde73b4539ade27ccc301613e368b944fL54-L63): Modified the branch checks in the `determine_tag` step to use `github.ref_name` instead of `github.base_ref`. Removed the `dependabotchanges` branch condition.