### PR TITLE
feat: disable purge protection of key vault

### DIFF
--- a/infra/deploy_keyvault.bicep
+++ b/infra/deploy_keyvault.bicep
@@ -35,9 +35,7 @@ resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' = {
     enabledForDeployment: true
     enabledForDiskEncryption: true
     enabledForTemplateDeployment: true
-    enableSoftDelete: false
     enableRbacAuthorization: true
-    enablePurgeProtection: true
     publicNetworkAccess: 'enabled'
     sku: {
       family: 'A'

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.34.44.8038",
-      "templateHash": "15962798193197746525"
+      "templateHash": "2966583538132786271"
     }
   },
   "parameters": {
@@ -451,7 +451,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.34.44.8038",
-              "templateHash": "1179876312013038352"
+              "templateHash": "7479964703030361933"
             }
           },
           "parameters": {
@@ -504,7 +504,6 @@
                 "enabledForDeployment": true,
                 "enabledForDiskEncryption": true,
                 "enabledForTemplateDeployment": true,
-                "enableSoftDelete": false,
                 "enableRbacAuthorization": true,
                 "publicNetworkAccess": "enabled",
                 "sku": {

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.34.44.8038",
-      "templateHash": "13937422806437579370"
+      "templateHash": "15962798193197746525"
     }
   },
   "parameters": {
@@ -451,7 +451,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.34.44.8038",
-              "templateHash": "10664495342911727649"
+              "templateHash": "1179876312013038352"
             }
           },
           "parameters": {
@@ -506,7 +506,6 @@
                 "enabledForTemplateDeployment": true,
                 "enableSoftDelete": false,
                 "enableRbacAuthorization": true,
-                "enablePurgeProtection": true,
                 "publicNetworkAccess": "enabled",
                 "sku": {
                   "family": "A",


### PR DESCRIPTION
This pull request updates the configuration for Key Vault resources in the infrastructure files, removing certain settings related to soft delete and purge protection, and regenerating template hashes to reflect these changes.

### Key Vault Configuration Updates:
* [`infra/deploy_keyvault.bicep`](diffhunk://#diff-82312b3acfa82a4f0980d7e0592f22b8db36f98965a61c340510f972ad7306faL38-L40): Removed `enableSoftDelete` and `enablePurgeProtection` properties from the Key Vault configuration. These settings are no longer explicitly defined.
* [`infra/main.json`](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L507-L509): Updated the Key Vault configuration to remove `enableSoftDelete` and `enablePurgeProtection` properties, aligning with the changes in the Bicep file.

### Template Hash Updates:
* [`infra/main.json`](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L8-R8): Regenerated `_generator.templateHash` values to reflect the updated Key Vault configuration. [[1]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L8-R8) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L454-R454)