### PR TITLE
fix: bring consistency for "cancel" behavior from home screen

### DIFF
--- a/src/frontend/src/components/uploadButton.tsx
+++ b/src/frontend/src/components/uploadButton.tsx
@@ -366,7 +366,7 @@ const FileUploadZone: React.FC<FileUploadZoneProps> = ({
         onConfirm={cancelAllUploads}
         onCancel={() => setShowLogoCancelDialog(false)}
         confirmText="Leave and lose progress"
-        cancelText="Stay here"
+        cancelText="Continue"
       />
       <ConfirmationDialog
         open={showFileLimitDialog}

--- a/src/frontend/src/pages/batchView.tsx
+++ b/src/frontend/src/pages/batchView.tsx
@@ -667,7 +667,7 @@ const BatchStoryPage = () => {
         onConfirm={handleLeave}
         onCancel={() => setShowLeaveDialog(false)}
         confirmText="Return to home and lose progress"
-        cancelText="Stay here"
+        cancelText="Continue"
       />
     </div>
   );


### PR DESCRIPTION
This pull request updates the wording in confirmation dialogs across the application to improve user clarity and consistency. Specifically, the "Cancel" button text has been changed from "Stay here" to "Continue" in two places.

Dialog text updates:

* [`src/frontend/src/components/uploadButton.tsx`](diffhunk://#diff-6ee566319b7b57a4566f4825bde5bc576033af50d62ccdb85f89e23e43d9850fL369-R369): Updated the `cancelText` in the file upload cancellation dialog from "Stay here" to "Continue" to align with the updated user experience.
* [`src/frontend/src/pages/batchView.tsx`](diffhunk://#diff-cdeb9de1e80ac6996465fb16cd07e14aa8d7467e05252cbcae76fe15b40efb7bL670-R670): Updated the `cancelText` in the leave confirmation dialog from "Stay here" to "Continue" for consistency.