### PR TITLE
feat: updated one click deployment github action parameters

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,7 +58,7 @@ jobs:
           az deployment group create \
             --resource-group ${{ env.RESOURCE_GROUP_NAME }} \
             --template-file infra/main.bicep \
-            --parameters ResourcePrefix=codegen AiLocation=northcentralus
+            --parameters AzureAiServiceLocation=northcentralus Prefix=codegen
 
 
       - name: Send Notification on Failure


### PR DESCRIPTION
## Purpose
This pull request updates the deployment workflow in `.github/workflows/deploy.yml` to align parameter naming conventions with Azure standards.

* **Deployment workflow parameter update**:
  - Updated the `az deployment group create` command to rename the `ResourcePrefix` parameter to `Prefix` and `AiLocation` to `AzureAiServiceLocation` for consistency with Azure naming conventions. (`.github/workflows/deploy.yml`, [.github/workflows/deploy.ymlL61-R61](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L61-R61))

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.