### PR TITLE
fix: To reuse Log Analytics across subscriptions

### DIFF
--- a/docs/CustomizingAzdParameters.md
+++ b/docs/CustomizingAzdParameters.md
@@ -25,5 +25,5 @@ azd env set AZURE_ENV_MODEL_CAPACITY 30
 
 Set the Log Analytics Workspace Id if you need to reuse the existing workspace which is already existing
 ```shell
-azd env set AZURE_ENV_LOG_ANALYTICS_WORKSPACE_ID '<Existing Log Analytics Workspace Id>'
+azd env set AZURE_ENV_LOG_ANALYTICS_WORKSPACE_ID '/subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.OperationalInsights/workspaces/<workspace-name>'
 ```

--- a/infra/deploy_ai_foundry.bicep
+++ b/infra/deploy_ai_foundry.bicep
@@ -15,6 +15,7 @@ param aiServicesId string
 param existingLogAnalyticsWorkspaceId string = ''
 
 var useExisting = !empty(existingLogAnalyticsWorkspaceId)
+var existingLawSubscription = useExisting ? split(existingLogAnalyticsWorkspaceId, '/')[2] : ''
 var existingLawResourceGroup = useExisting ? split(existingLogAnalyticsWorkspaceId, '/')[4] : ''
 var existingLawName = useExisting ? split(existingLogAnalyticsWorkspaceId, '/')[8] : ''
 
@@ -41,7 +42,7 @@ resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' existing = {
 
 resource existingLogAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2020-08-01' existing = if (useExisting) {
   name: existingLawName
-  scope: resourceGroup(existingLawResourceGroup)
+  scope: resourceGroup(existingLawSubscription, existingLawResourceGroup)
 }
 
 resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2023-09-01' = if (!useExisting) {


### PR DESCRIPTION
## Purpose
This pull request introduces improvements to the handling of existing Log Analytics Workspace IDs in both documentation and infrastructure code. The changes ensure consistency and correctness when specifying the full resource ID format and enhance the deployment logic to accommodate subscriptions explicitly.

### Documentation Updates:

* [`docs/CustomizingAzdParameters.md`](diffhunk://#diff-6eec6ba43f4d3beb5835ad60e22b6974f1224c7b5ff024f690cd9549e8b4aec7L28-R28): Updated the example for setting the `AZURE_ENV_LOG_ANALYTICS_WORKSPACE_ID` to use the full resource ID format, including subscription, resource group, and workspace name.

### Infrastructure Code Enhancements:

* [`infra/deploy_ai_foundry.bicep`](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626R18): Added logic to extract the subscription ID (`existingLawSubscription`) from the `existingLogAnalyticsWorkspaceId` parameter, ensuring proper handling of workspace scope.
* [`infra/deploy_ai_foundry.bicep`](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626L44-R45): Modified the `existingLogAnalyticsWorkspace` resource declaration to include the subscription ID in the scope, improving accuracy when referencing existing resources.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->


## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.