### PR TITLE
feat: implement interactive quota check script with user inputs

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -27,7 +27,7 @@ hooks:
       shell: sh
       run: >
         chmod u+r+x ./scripts/validate_model_deployment_quota.sh; chmod u+r+x ./scripts/validate_model_quota.sh; ./scripts/validate_model_deployment_quota.sh --SubscriptionId "$AZURE_SUBSCRIPTION_ID" --Location "${AZURE_AISERVICE_LOCATION:-japaneast}" --ModelsParameter "aiModelDeployments"
-      interactive: false
+      interactive: true
       continueOnError: false
 
     windows:

--- a/azure.yaml
+++ b/azure.yaml
@@ -35,5 +35,5 @@ hooks:
       run: >
         $location = if ($env:AZURE_AISERVICE_LOCATION) { $env:AZURE_AISERVICE_LOCATION } else { "japaneast" };
         ./scripts/validate_model_deployment_quota.ps1 -SubscriptionId $env:AZURE_SUBSCRIPTION_ID -Location $location -ModelsParameter "aiModelDeployments"
-      interactive: false
+      interactive: true
       continueOnError: false

--- a/scripts/validate_model_deployment_quota.ps1
+++ b/scripts/validate_model_deployment_quota.ps1
@@ -15,58 +15,64 @@ if (-not $ModelsParameter) { $MissingParams += "ModelsParameter" }
 
 if ($MissingParams.Count -gt 0) {
     Write-Error "❌ ERROR: Missing required parameters: $($MissingParams -join ', ')"
+    Write-Host "Usage: validate_model_deployment_quota.ps1 -SubscriptionId <SUBSCRIPTION_ID> -Location <LOCATION> -ModelsParameter <MODELS_PARAMETER>"
     exit 1
 }
 
 # Load model deployments from parameter file
 $JsonContent = Get-Content -Path "./infra/main.parameters.json" -Raw | ConvertFrom-Json
-if (-not $JsonContent) {
-    Write-Error "❌ ERROR: Failed to parse main.parameters.json. Ensure the JSON file is valid."
-    exit 1
-}
-
 $aiModelDeployments = $JsonContent.parameters.$ModelsParameter.value
 if (-not $aiModelDeployments -or -not ($aiModelDeployments -is [System.Collections.IEnumerable])) {
-    Write-Error "❌ ERROR: The specified property '$ModelsParameter' does not exist or is not an array."
+    Write-Error "❌ ERROR: Failed to parse main.parameters.json or missing '$ModelsParameter'"
     exit 1
 }
 
-# Check if AI Foundry exists and has all required model deployments
-$existing = $null
+# Try to discover AI Foundry name if not set
+if (-not $AiFoundryName -and $ResourceGroup) {
+    $AiFoundryName = az cognitiveservices account list `
+        --resource-group $ResourceGroup `
+        --query "sort_by([?kind=='AIServices'], &name)[0].name" `
+        -o tsv 2>$null
+}
+
+# Check if AI Foundry exists
 if ($AiFoundryName -and $ResourceGroup) {
     $existing = az cognitiveservices account show `
         --name $AiFoundryName `
         --resource-group $ResourceGroup `
         --query "name" --output tsv 2>$null
+
+    if ($existing) {
+        # adding into .env
+        azd env set AZURE_AIFOUNDRY_NAME $existing | Out-Null
+
+        $deployedModelsOutput = az cognitiveservices account deployment list `
+            --name $AiFoundryName `
+            --resource-group $ResourceGroup `
+            --query "[].name" --output tsv 2>$null
+
+        $deployedModels = @()
+        if ($deployedModelsOutput -is [string]) {
+            $deployedModels += $deployedModelsOutput
+        } elseif ($deployedModelsOutput) {
+            $deployedModels = $deployedModelsOutput -split "`r?`n"
+        }
+
+        $requiredDeployments = $aiModelDeployments | ForEach-Object { $_.name }
+        $missingDeployments = $requiredDeployments | Where-Object { $_ -notin $deployedModels }
+
+        if ($missingDeployments.Count -eq 0) {
+            Write-Host "ℹ️ AI Foundry '$AiFoundryName' exists and all required model deployments are already provisioned."
+            Write-Host "⏭️ Skipping quota validation."
+            exit 0
+        } else {
+            Write-Host "🔍 AI Foundry exists, but the following model deployments are missing: $($missingDeployments -join ', ')"
+            Write-Host "➡️ Proceeding with quota validation for missing models..."
+        }
+    }
 }
 
-if ($existing) {
-    $deployedModelsOutput = az cognitiveservices account deployment list `
-        --name $AiFoundryName `
-        --resource-group $ResourceGroup `
-        --query "[].name" --output tsv 2>$null
-
-    $deployedModels = @()
-    if ($deployedModelsOutput -is [string]) {
-        $deployedModels += $deployedModelsOutput
-    } elseif ($deployedModelsOutput) {
-        $deployedModels = $deployedModelsOutput -split "`r?`n"
-    }
-
-    $requiredDeployments = $aiModelDeployments | ForEach-Object { $_.name }
-    $missingDeployments = $requiredDeployments | Where-Object { $_ -notin $deployedModels }
-
-    if ($missingDeployments.Count -eq 0) {
-        Write-Host "ℹ️ AI Foundry '$AiFoundryName' exists and all required model deployments are already provisioned."
-        Write-Host "⏭️ Skipping quota validation."
-        exit 0
-    } else {
-        Write-Host "🔍 AI Foundry exists, but the following model deployments are missing: $($missingDeployments -join ', ')"
-        Write-Host "➡️ Proceeding with quota validation for missing models..."
-    }
-}
-
-# Run quota validation for all models
+# Run quota validation
 az account set --subscription $SubscriptionId
 Write-Host "🎯 Active Subscription: $(az account show --query '[name, id]' --output tsv)"
 
@@ -78,7 +84,8 @@ foreach ($deployment in $aiModelDeployments) {
     $type = if ($env:AZURE_ENV_MODEL_DEPLOYMENT_TYPE) { $env:AZURE_ENV_MODEL_DEPLOYMENT_TYPE } else { $deployment.sku.name }
     $capacity = if ($env:AZURE_ENV_MODEL_CAPACITY) { $env:AZURE_ENV_MODEL_CAPACITY } else { $deployment.sku.capacity }
 
-    Write-Host "`n🔍 Validating model deployment: $name ..."
+    Write-Host ""
+    Write-Host "🔍 Validating model deployment: $name ..."
     & .\scripts\validate_model_quota.ps1 -Location $Location -Model $model -Capacity $capacity -DeploymentType $type
     $exitCode = $LASTEXITCODE
 

--- a/scripts/validate_model_quota.ps1
+++ b/scripts/validate_model_quota.ps1
@@ -10,7 +10,6 @@ $MissingParams = @()
 if (-not $Location) { $MissingParams += "location" }
 if (-not $Model) { $MissingParams += "model" }
 if (-not $Capacity) { $MissingParams += "capacity" }
-if (-not $DeploymentType) { $MissingParams += "deployment-type" }
 
 if ($MissingParams.Count -gt 0) {
     Write-Error "❌ ERROR: Missing required parameters: $($MissingParams -join ', ')"
@@ -35,7 +34,7 @@ function Check-Quota {
     try {
         $ModelInfoRaw = az cognitiveservices usage list --location $Region --query "[?name.value=='$ModelType']" --output json
         $ModelInfo = $ModelInfoRaw | ConvertFrom-Json
-        if (-not $ModelInfo) { return }
+        if (-not $ModelInfo) { return $null }
 
         $CurrentValue = ($ModelInfo | Where-Object { $_.name.value -eq $ModelType }).currentValue
         $Limit = ($ModelInfo | Where-Object { $_.name.value -eq $ModelType }).limit
@@ -52,11 +51,23 @@ function Check-Quota {
             Available = $Available
         }
     } catch {
-        return
+        return $null
     }
 }
 
-# First, check the user-specified region
+function Show-Table {
+    Write-Host "`n-------------------------------------------------------------------------------------------------------------"
+    Write-Host "| No.  | Region            | Model Name                           | Limit   | Used    | Available |"
+    Write-Host "-------------------------------------------------------------------------------------------------------------"
+    $count = 1
+    foreach ($entry in $AllResults) {
+        Write-Host ("| {0,-4} | {1,-16} | {2,-35} | {3,-7} | {4,-7} | {5,-9} |" -f $count, $entry.Region, $entry.Model, $entry.Limit, $entry.Used, $entry.Available)
+        $count++
+    }
+    Write-Host "-------------------------------------------------------------------------------------------------------------"
+}
+
+# ----------- First check the user-specified region -----------
 Write-Host "`n🔍 Checking quota in the requested region '$Location'..."
 $PrimaryResult = Check-Quota -Region $Location
 
@@ -72,45 +83,52 @@ if ($PrimaryResult) {
     Write-Host "`n⚠️  Could not retrieve quota info for region '$Location'. Checking fallback regions..."
 }
 
-# Remove primary region from fallback list
+# ----------- Check all other fallback regions -----------
 $FallbackRegions = $PreferredRegions | Where-Object { $_ -ne $Location }
+$EligibleFallbacks = @()
 
 foreach ($region in $FallbackRegions) {
     $result = Check-Quota -Region $region
     if ($result) {
         $AllResults += $result
+        if ($result.Available -ge $Capacity) {
+            $EligibleFallbacks += $result
+        }
     }
 }
 
-# Display Results Table
-Write-Host "`n-------------------------------------------------------------------------------------------------------------"
-Write-Host "| No.  | Region            | Model Name                           | Limit   | Used    | Available |"
-Write-Host "-------------------------------------------------------------------------------------------------------------"
+# ----------- Show Table of All Regions Checked -----------
+Show-Table
 
-$count = 1
-foreach ($entry in $AllResults) {
-    $modelShort = $entry.Model.Substring($entry.Model.LastIndexOf(".") + 1)
-    Write-Host ("| {0,-4} | {1,-16} | {2,-35} | {3,-7} | {4,-7} | {5,-9} |" -f $count, $entry.Region, $entry.Model, $entry.Limit, $entry.Used, $entry.Available)
-    $count++
-}
-Write-Host "-------------------------------------------------------------------------------------------------------------"
-
-# Suggest fallback regions
-$EligibleFallbacks = $AllResults | Where-Object { $_.Region -ne $Location -and $_.Available -ge $Capacity }
-
+# ----------- If eligible fallback regions found, ask user -----------
 if ($EligibleFallbacks.Count -gt 0) {
     Write-Host "`n❌ Deployment cannot proceed in '$Location'."
-    Write-Host "➡️ You can retry using one of the following regions with sufficient quota:`n"
-    foreach ($region in $EligibleFallbacks) {
-        Write-Host "   • $($region.Region) (Available: $($region.Available))"
-    }
+    Write-Host "➡️  Found fallback regions with sufficient quota."
+    
+    while ($true) {
+        Write-Host "`nPlease enter a fallback region from the list above to proceed:"
+        $NewLocation = Read-Host "Enter region"
 
-    Write-Host "`n🔧 To proceed, run:"
-    Write-Host "    azd env set AZURE_AISERVICE_LOCATION '<region>'"
-    Write-Host "📌 To confirm it's set correctly, run:"
-    Write-Host "    azd env get-value AZURE_AISERVICE_LOCATION"
-    Write-Host "▶️  Once confirmed, re-run azd up to deploy the model in the new region."
-    exit 2
+        if (-not $NewLocation) {
+            Write-Host "❌ No location entered. Exiting."
+            exit 1
+        }
+
+        $UserResult = Check-Quota -Region $NewLocation
+        if (-not $UserResult) {
+            Write-Host "⚠️ Could not retrieve quota info for region '$NewLocation'. Try again."
+            continue
+        }
+
+        if ($UserResult.Available -ge $Capacity) {
+            Write-Host "✅ Sufficient quota found in '$NewLocation'. Proceeding with deployment."
+            azd env set AZURE_AISERVICE_LOCATION "$NewLocation" | Out-Null
+            Write-Host "➡️  Set AZURE_AISERVICE_LOCATION to '$NewLocation'."
+            exit 0
+        } else {
+            Write-Host "❌ Insufficient quota in '$NewLocation'. Try another."
+        }
+    }
 }
 
 Write-Error "`n❌ ERROR: No available quota found in any region."

--- a/scripts/validate_model_quota.ps1
+++ b/scripts/validate_model_quota.ps1
@@ -56,15 +56,15 @@ function Check-Quota {
 }
 
 function Show-Table {
-    Write-Host "`n-------------------------------------------------------------------------------------------------------------"
-    Write-Host "| No.  | Region            | Model Name                           | Limit   | Used    | Available |"
-    Write-Host "-------------------------------------------------------------------------------------------------------------"
+    Write-Host "`n--------------------------------------------------------------------------------------------"
+    Write-Host "| No. | Region         | Model Name                          | Limit | Used  | Available |"
+    Write-Host "--------------------------------------------------------------------------------------------"
     $count = 1
     foreach ($entry in $AllResults) {
-        Write-Host ("| {0,-4} | {1,-16} | {2,-35} | {3,-7} | {4,-7} | {5,-9} |" -f $count, $entry.Region, $entry.Model, $entry.Limit, $entry.Used, $entry.Available)
+        Write-Host ("| {0,-3} | {1,-14} | {2,-35} | {3,-5} | {4,-5} | {5,-9} |" -f $count, $entry.Region, $entry.Model, $entry.Limit, $entry.Used, $entry.Available)
         $count++
     }
-    Write-Host "-------------------------------------------------------------------------------------------------------------"
+    Write-Host "--------------------------------------------------------------------------------------------"
 }
 
 # ----------- First check the user-specified region -----------
@@ -98,6 +98,7 @@ foreach ($region in $FallbackRegions) {
 }
 
 # ----------- Show Table of All Regions Checked -----------
+$AllResults = $AllResults | Where-Object { $_.Available -gt 50 }
 Show-Table
 
 # ----------- If eligible fallback regions found, ask user -----------

--- a/scripts/validate_model_quota.sh
+++ b/scripts/validate_model_quota.sh
@@ -117,7 +117,7 @@ index=1
 for result in "${ALL_RESULTS[@]}"; do
   IFS='|' read -r region limit used available <<< "$result"
   if [[ "$available" -gt 50 ]]; then
-    printf "| %-3s | %-14s | %-31s | %-5s | %-5s | %-9s |\n" "$index" "$region" "$MODEL_TYPE" "$limit" "$used" "$available"
+    printf "| %-3s | %-16s | %-33s | %-6s | %-6s | %-9s |\n" "$index" "$region" "$MODEL_TYPE" "$limit" "$used" "$available"
     ((index++))
   fi
 done

--- a/scripts/validate_model_quota.sh
+++ b/scripts/validate_model_quota.sh
@@ -110,14 +110,16 @@ done
 
 # -------------------- Print Results Table --------------------
 echo ""
-printf "%-6s | %-18s | %-35s | %-8s | %-8s | %-9s\n" "No." "Region" "Model Name" "Limit" "Used" "Available"
-printf -- "-------------------------------------------------------------------------------------------------------------\n"
+printf "%-5s | %-16s | %-33s | %-6s | %-6s | %-9s\n" "No." "Region" "Model Name" "Limit" "Used" "Available"
+printf -- "---------------------------------------------------------------------------------------------\n"
 
 index=1
 for result in "${ALL_RESULTS[@]}"; do
   IFS='|' read -r region limit used available <<< "$result"
-  printf "| %-4s | %-16s | %-33s | %-7s | %-7s | %-9s |\n" "$index" "$region" "$MODEL_TYPE" "$limit" "$used" "$available"
-  ((index++))
+  if [[ "$available" -gt 50 ]]; then
+    printf "| %-3s | %-14s | %-31s | %-5s | %-5s | %-9s |\n" "$index" "$region" "$MODEL_TYPE" "$limit" "$used" "$available"
+    ((index++))
+  fi
 done
 printf -- "-------------------------------------------------------------------------------------------------------------\n"
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...
This pull request introduces several changes to improve the validation and deployment of AI models in Azure services. Key updates include enhanced parameter validation, better handling of missing deployments, and improved quota checks across regions. The changes span multiple scripts and configuration files, ensuring more robust and user-friendly workflows.

### Enhancements to Parameter Validation and Error Handling:
* Updated parameter names in `scripts/validate_model_deployment_quota.sh` and `scripts/validate_model_deployment_quota.ps1` for consistency (`--subscription` → `--SubscriptionId`, `--location` → `--Location`, `--models-parameter` → `--ModelsParameter`) and improved error messages for missing or unknown parameters. [[1]](diffhunk://#diff-1485c0125e236c5138a63293d8d71a2b7b252bef8cf9feacc805090b08e7c7c9L9-R81) [[2]](diffhunk://#diff-f436047f2fd4d73338a85fbba88d0d1d91e5f485b6e8d3b97c8cdabff0c1e4d2L7-R69)
* Added checks for AI Foundry existence and missing deployments in both `.sh` and `.ps1` scripts, skipping quota validation if all required deployments are provisioned. [[1]](diffhunk://#diff-1485c0125e236c5138a63293d8d71a2b7b252bef8cf9feacc805090b08e7c7c9L9-R81) [[2]](diffhunk://#diff-f436047f2fd4d73338a85fbba88d0d1d91e5f485b6e8d3b97c8cdabff0c1e4d2L7-R69)

### Improvements to Quota Validation Logic:
* Enhanced fallback region handling in `scripts/validate_model_quota.ps1` to allow user selection of regions with sufficient quota, including a table display of all checked regions. [[1]](diffhunk://#diff-be9d5b27ecd8e64d43cdb15bfc501e6a9a00c4a91309c457a6167a1746439540L36-R37) [[2]](diffhunk://#diff-be9d5b27ecd8e64d43cdb15bfc501e6a9a00c4a91309c457a6167a1746439540L56-R134)
* Modified error messages to differentiate between quota validation failures and missing deployments. [[1]](diffhunk://#diff-f436047f2fd4d73338a85fbba88d0d1d91e5f485b6e8d3b97c8cdabff0c1e4d2L59) [[2]](diffhunk://#diff-f436047f2fd4d73338a85fbba88d0d1d91e5f485b6e8d3b97c8cdabff0c1e4d2L68-R95)

### Configuration Updates:
* Changed `interactive` mode for PowerShell hooks in `azure.yaml` to `true` for better user interaction during execution.
* Added an output variable `AZURE_AIFOUNDRY_NAME` in `infra/main.bicep` for easier reference to AI Foundry resources.

### Resource Adjustments:
* Reduced the default capacity for AI model deployments in `infra/main.parameters.json` from 200 to 50 to optimize resource usage.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [ ] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [ ] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->

