### PR TITLE
ci: Added workflow for checking broken links in Markdown files

### DIFF
--- a/.github/workflows/broken-links-checker.yml
+++ b/.github/workflows/broken-links-checker.yml
@@ -1,0 +1,57 @@
+name: Broken Link Checker
+
+on:
+  pull_request:
+    paths:
+      - '**/*.md'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  markdown-link-check:
+    name: Check Markdown Broken Links
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # For PR : Get only changed markdown files
+      - name: Get changed markdown files (PR only)
+        id: changed-markdown-files
+        if: github.event_name == 'pull_request'
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46
+        with:
+          files: |
+            **/*.md
+
+
+      # For PR: Check broken links only in changed files
+      - name: Check Broken Links in Changed Markdown Files
+        id: lychee-check-pr
+        if: github.event_name == 'pull_request' && steps.changed-markdown-files.outputs.any_changed == 'true'
+        uses: lycheeverse/lychee-action@v2.4.1
+        with:
+          args: >
+            --verbose --exclude-mail --no-progress --exclude ^https?://
+            ${{ steps.changed-markdown-files.outputs.all_changed_files }}
+          failIfEmpty: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # For manual trigger: Check all markdown files in repo
+      - name: Check Broken Links in All Markdown Files in Entire Repo (Manual Trigger)
+        id: lychee-check-manual
+        if: github.event_name == 'workflow_dispatch'
+        uses: lycheeverse/lychee-action@v2.4.1
+        with:
+          args: >
+            --verbose --exclude-mail --no-progress --exclude ^https?://
+            '**/*.md'
+          failIfEmpty: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Purpose
This pull request adds a new GitHub Actions workflow to check for broken links in Markdown files. The workflow is triggered on pull requests and manual dispatch, ensuring link validation in changed files or the entire repository as needed.

### New workflow for broken link checking:

* [`.github/workflows/broken-links-checker.yml`](diffhunk://#diff-67e26d77769066e1f1b5633a89f931c691eabfd57782a0767fa13ebb15319af4R1-R57): Created a GitHub Actions workflow named "Broken Link Checker" to validate links in Markdown files. The workflow runs on pull requests to check only changed Markdown files and can be manually triggered to check all Markdown files in the repository.* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->