### PR TITLE
fix: removed the container creation from code to avoid permission issue

### DIFF
--- a/src/backend/common/database/cosmosdb.py
+++ b/src/backend/common/database/cosmosdb.py
@@ -2,7 +2,6 @@ from datetime import datetime, timezone
 from typing import Dict, List, Optional
 from uuid import UUID, uuid4
 
-from azure.cosmos import PartitionKey, exceptions
 from azure.cosmos.aio import CosmosClient
 from azure.cosmos.aio._database import DatabaseProxy
 from azure.cosmos.exceptions import (

--- a/src/backend/common/database/cosmosdb.py
+++ b/src/backend/common/database/cosmosdb.py
@@ -49,32 +49,27 @@ class CosmosDBClient(DatabaseBase):
         try:
             self.client = CosmosClient(url=self.endpoint, credential=self.credential)
             database = self.client.get_database_client(self.database_name)
-
-            self.batch_container = await self._get_or_create_container(
-                database, self.batch_container_name, "/batch_id"
+            self.batch_container = await self._get_container(
+                database, self.batch_container_name
             )
-            self.file_container = await self._get_or_create_container(
-                database, self.file_container_name, "/file_id"
+            self.file_container = await self._get_container(
+                database, self.file_container_name
             )
-            self.log_container = await self._get_or_create_container(
-                database, self.log_container_name, "/log_id"
+            self.log_container = await self._get_container(
+                database, self.log_container_name
             )
         except Exception as e:
             self.logger.error("Failed to initialize Cosmos DB", error=str(e))
             raise
 
-    async def _get_or_create_container(
-        self, database: DatabaseProxy, container_name, partition_key
+    async def _get_container(
+        self, database: DatabaseProxy, container_name
     ):
         try:
-            return await database.create_container(
-                id=container_name, partition_key=PartitionKey(path=partition_key)
-            )
-        except exceptions.CosmosResourceExistsError:
             return database.get_container_client(container_name)
 
         except Exception as e:
-            self.logger.error("Failed to Get/Create cosmosdb container", error=str(e))
+            self.logger.error("Failed to Get cosmosdb container", error=str(e))
             raise
 
     async def create_batch(self, user_id: str, batch_id: UUID) -> BatchRecord:


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This pull request refactors the Cosmos DB initialization logic to simplify container access by removing the logic for creating containers if they do not exist. Instead, the code now directly fetches existing containers. Corresponding unit tests have been updated to reflect this new approach.

**Cosmos DB Initialization Refactor:**

* The `initialize_cosmos` method in `cosmosdb.py` now uses a new `_get_container` helper that only fetches containers with `get_container_client` instead of attempting to create them if they don't exist. This removes the need for handling container creation and related exceptions.

**Test Updates:**

* All unit tests in `cosmosdb_test.py` have been updated to mock and assert calls to `get_container_client` instead of `create_container`, reflecting the new logic that containers are only fetched, not created. [[1]](diffhunk://#diff-980d8d888ca32c8186461c510d0876daa8db4b95e5647ace02f8ae7dc5d608dfL62-R63) [[2]](diffhunk://#diff-980d8d888ca32c8186461c510d0876daa8db4b95e5647ace02f8ae7dc5d608dfL72-R75) [[3]](diffhunk://#diff-980d8d888ca32c8186461c510d0876daa8db4b95e5647ace02f8ae7dc5d608dfL90-R98) [[4]](diffhunk://#diff-980d8d888ca32c8186461c510d0876daa8db4b95e5647ace02f8ae7dc5d608dfL107-R113) [[5]](diffhunk://#diff-980d8d888ca32c8186461c510d0876daa8db4b95e5647ace02f8ae7dc5d608dfL125-R125)
* Test error scenarios now simulate failures in fetching containers rather than in creating them, and assertion messages have been updated accordingly. [[1]](diffhunk://#diff-980d8d888ca32c8186461c510d0876daa8db4b95e5647ace02f8ae7dc5d608dfL90-R98) [[2]](diffhunk://#diff-980d8d888ca32c8186461c510d0876daa8db4b95e5647ace02f8ae7dc5d608dfL107-R113) [[3]](diffhunk://#diff-980d8d888ca32c8186461c510d0876daa8db4b95e5647ace02f8ae7dc5d608dfL125-R125)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [ ] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->

