### PR TITLE
chore: Add user name as CreatedBy tag while deployment

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -134,6 +134,8 @@ var modelDeployment = {
 
 var abbrs = loadJsonContent('./abbreviations.json')
 
+var deployerInfo = deployer()
+
 // ========== Resource Group Tag ========== //
 resource resourceGroupTags 'Microsoft.Resources/tags@2021-04-01' = {
   name: 'default'
@@ -141,6 +143,7 @@ resource resourceGroupTags 'Microsoft.Resources/tags@2021-04-01' = {
     tags: {
       ...allTags
       TemplateName: 'Code Modernization'
+      CreatedBy: split(deployerInfo.userPrincipalName, '@')[0] 
     }
   }
 }


### PR DESCRIPTION
## Purpose
This pull request makes a small but useful improvement to the resource group tagging logic in `infra/main.bicep`. The change adds a new `CreatedBy` tag that automatically sets the creator's username based on the deployment principal.

* Tagging enhancement: The `CreatedBy` tag is now added to the resource group tags, using the username portion of the `userPrincipalName` from the deployer context.
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [ ] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [X] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->

