### PR TITLE
Fix for Explicit returns mixed with implicit (fall through) returns

### DIFF
--- a/src/backend/sql_agents/helpers/comms_manager.py
+++ b/src/backend/sql_agents/helpers/comms_manager.py
@@ -79,6 +79,8 @@ class CommsManager:
                         ),
                         None,
                     )
+            # No matching case found, so explicitly return None
+            return None
 
     # class for termination strategy
     class ApprovalTerminationStrategy(TerminationStrategy):


### PR DESCRIPTION
The best fix is to add an explicit `return None` statement at the end of the `select_agent` method. This will ensure the method always returns a value explicitly, even if no branch in the `match` is taken (e.g. if `history[-1].name` is an unexpected value). This change will clarify developer intention and satisfy CodeQL. Only `src/backend/sql_agents/helpers/comms_manager.py` around the `select_agent` method needs modification; specifically, add an explicit `return None` after the `match` statement.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._