### PR TITLE
ci: refactor notification email templates

### DIFF
--- a/.github/workflows/deploy-orchestrator.yml
+++ b/.github/workflows/deploy-orchestrator.yml
@@ -102,25 +102,6 @@ jobs:
       TEST_SUITE: ${{ inputs.trigger_type == 'workflow_dispatch' && inputs.run_e2e_tests || 'GoldenPath-Testing' }}
     secrets: inherit
 
-  send-notification:
-    if: "!cancelled()"
-    needs: [docker-build, deploy, e2e-test]
-    uses: ./.github/workflows/job-send-notification.yml
-    with:
-      trigger_type: ${{ inputs.trigger_type }}
-      waf_enabled: ${{ inputs.waf_enabled }}
-      EXP: ${{ inputs.EXP }}
-      run_e2e_tests: ${{ inputs.run_e2e_tests }}
-      existing_webapp_url: ${{ inputs.existing_webapp_url }}
-      deploy_result: ${{ needs.deploy.result }}
-      e2e_test_result: ${{ needs.e2e-test.result }}
-      CONTAINER_WEB_APPURL: ${{ needs.deploy.outputs.CONTAINER_WEB_APPURL }}
-      RESOURCE_GROUP_NAME: ${{ needs.deploy.outputs.RESOURCE_GROUP_NAME }}
-      QUOTA_FAILED: ${{ needs.deploy.outputs.QUOTA_FAILED }}
-      TEST_SUCCESS: ${{ needs.e2e-test.outputs.TEST_SUCCESS }}
-      TEST_REPORT_URL: ${{ needs.e2e-test.outputs.TEST_REPORT_URL }}
-    secrets: inherit
-
   cleanup-deployment:
     if: "!cancelled() && needs.deploy.result == 'success' && needs.deploy.outputs.RESOURCE_GROUP_NAME != '' && inputs.existing_webapp_url == '' && (inputs.trigger_type != 'workflow_dispatch' || inputs.cleanup_resources)"
     needs: [docker-build, deploy, e2e-test]
@@ -135,4 +116,24 @@ jobs:
       AZURE_ENV_OPENAI_LOCATION: ${{ needs.deploy.outputs.AZURE_ENV_OPENAI_LOCATION }}
       ENV_NAME: ${{ needs.deploy.outputs.ENV_NAME }}
       IMAGE_TAG: ${{ needs.deploy.outputs.IMAGE_TAG }}
+    secrets: inherit
+
+  send-notification:
+    if: "!cancelled()"
+    needs: [docker-build, deploy, e2e-test, cleanup-deployment]
+    uses: ./.github/workflows/job-send-notification.yml
+    with:
+      trigger_type: ${{ inputs.trigger_type }}
+      waf_enabled: ${{ inputs.waf_enabled }}
+      EXP: ${{ inputs.EXP }}
+      run_e2e_tests: ${{ inputs.run_e2e_tests }}
+      existing_webapp_url: ${{ inputs.existing_webapp_url }}
+      deploy_result: ${{ needs.deploy.result }}
+      e2e_test_result: ${{ needs.e2e-test.result }}
+      CONTAINER_WEB_APPURL: ${{ needs.deploy.outputs.CONTAINER_WEB_APPURL }}
+      RESOURCE_GROUP_NAME: ${{ needs.deploy.outputs.RESOURCE_GROUP_NAME }}
+      QUOTA_FAILED: ${{ needs.deploy.outputs.QUOTA_FAILED }}
+      TEST_SUCCESS: ${{ needs.e2e-test.outputs.TEST_SUCCESS }}
+      TEST_REPORT_URL: ${{ needs.e2e-test.outputs.TEST_REPORT_URL }}
+      cleanup_result: ${{ needs.cleanup-deployment.result }}
     secrets: inherit

--- a/.github/workflows/job-send-notification.yml
+++ b/.github/workflows/job-send-notification.yml
@@ -137,7 +137,7 @@ jobs:
           EMAIL_BODY=$(cat <<EOF
           {
             "body": "<p>Dear Team,</p><p>We would like to inform you that the ${ACCELERATOR_NAME} deployment has failed due to insufficient quota.</p><p><strong>Status Summary:</strong><br><table border='1' cellpadding='5' cellspacing='0'><tr><th>Stage</th><th>Status</th></tr><tr><td>Deployment</td><td>❌ FAILED (Insufficient Quota)</td></tr><tr><td>E2E Tests</td><td>⏭️ SKIPPED</td></tr><tr><td>Cleanup</td><td>${CLEANUP_STATUS}</td></tr></table></p><p><strong>Configuration:</strong> ${CONFIG_LABEL}</p><p><strong>Run URL:</strong> <a href='${RUN_URL}'>${RUN_URL}</a></p><p>Please resolve the quota issue and retry the deployment.</p><p>Best regards,<br>Your Automation Team</p>",
-            "subject": "[CI/CD-Automation] [${ACCELERATOR_NAME}] Insufficient Quota"
+            "subject": "❌[CI/CD-Automation] [${ACCELERATOR_NAME}] Insufficient Quota"
           }
           EOF
           )
@@ -162,7 +162,7 @@ jobs:
           EMAIL_BODY=$(cat <<EOF
           {
             "body": "<p>Dear Team,</p><p>We would like to inform you that the ${ACCELERATOR_NAME} deployment has failed.</p><p><strong>Status Summary:</strong><br><table border='1' cellpadding='5' cellspacing='0'><tr><th>Stage</th><th>Status</th></tr><tr><td>Deployment</td><td>❌ FAILED (Deployment Issue)</td></tr><tr><td>E2E Tests</td><td>⏭️ SKIPPED</td></tr><tr><td>Cleanup</td><td>${CLEANUP_STATUS}</td></tr></table></p><p><strong>Deployment Details:</strong><br>• Resource Group: ${RESOURCE_GROUP}</p><p><strong>Configuration:</strong> ${CONFIG_LABEL}</p><p><strong>Run URL:</strong> <a href='${RUN_URL}'>${RUN_URL}</a></p><p>Please investigate the deployment failure at your earliest convenience.</p><p>Best regards,<br>Your Automation Team</p>",
-            "subject": "[CI/CD-Automation] [${ACCELERATOR_NAME}] Deployment-Failed"
+            "subject": "❌[CI/CD-Automation] [${ACCELERATOR_NAME}] Deployment-Failed"
           }
           EOF
           )
@@ -199,7 +199,7 @@ jobs:
             EMAIL_BODY=$(cat <<EOF
           {
             "body": "<p>Dear Team,</p><p>We would like to inform you that the ${ACCELERATOR_NAME} deployment has completed successfully.</p><p><strong>Status Summary:</strong><br><table border='1' cellpadding='5' cellspacing='0'><tr><th>Stage</th><th>Status</th></tr><tr><td>Deployment</td><td>✅ SUCCESS</td></tr><tr><td>E2E Tests</td><td>⏭️ SKIPPED</td></tr><tr><td>Cleanup</td><td>${CLEANUP_STATUS}</td></tr></table></p><p><strong>Deployment Details:</strong><br>• Resource Group: ${RESOURCE_GROUP}<br>• Web App URL: <a href='${WEBAPP_URL}'>${WEBAPP_URL}</a></p><p><strong>Configuration:</strong> ${CONFIG_LABEL}</p><p><strong>Run URL:</strong> <a href='${RUN_URL}'>${RUN_URL}</a></p><p>Best regards,<br>Your Automation Team</p>",
-            "subject": "[CI/CD-Automation] [${ACCELERATOR_NAME}] Success"
+            "subject": "✅[CI/CD-Automation] [${ACCELERATOR_NAME}] Success"
           }
           EOF
             )
@@ -207,7 +207,7 @@ jobs:
             EMAIL_BODY=$(cat <<EOF
           {
             "body": "<p>Dear Team,</p><p>We would like to inform you that the ${ACCELERATOR_NAME} deployment and test automation has completed successfully.</p><p><strong>Status Summary:</strong><br><table border='1' cellpadding='5' cellspacing='0'><tr><th>Stage</th><th>Status</th></tr><tr><td>Deployment</td><td>✅ SUCCESS</td></tr><tr><td>E2E Tests</td><td>✅ SUCCESS</td></tr><tr><td>Cleanup</td><td>${CLEANUP_STATUS}</td></tr></table></p><p><strong>Deployment Details:</strong><br>• Resource Group: ${RESOURCE_GROUP}<br>• Web App URL: <a href='${WEBAPP_URL}'>${WEBAPP_URL}</a><br>• Test Suite: ${TEST_SUITE_NAME}<br>• Test Report: <a href='${TEST_REPORT_URL}'>View Report</a></p><p><strong>Configuration:</strong> ${CONFIG_LABEL}</p><p><strong>Run URL:</strong> <a href='${RUN_URL}'>${RUN_URL}</a></p><p>Best regards,<br>Your Automation Team</p>",
-            "subject": "[CI/CD-Automation] [${ACCELERATOR_NAME}] Success"
+            "subject": "✅[CI/CD-Automation] [${ACCELERATOR_NAME}] Success"
           }
           EOF
             )
@@ -242,7 +242,7 @@ jobs:
           EMAIL_BODY=$(cat <<EOF
           {
             "body": "<p>Dear Team,</p><p>We would like to inform you that ${ACCELERATOR_NAME} test automation has failed.</p><p><strong>Status Summary:</strong><br><table border='1' cellpadding='5' cellspacing='0'><tr><th>Stage</th><th>Status</th></tr><tr><td>Deployment</td><td>✅ SUCCESS</td></tr><tr><td>E2E Tests</td><td>❌ FAILED</td></tr><tr><td>Cleanup</td><td>${CLEANUP_STATUS}</td></tr></table></p><p><strong>Deployment Details:</strong><br>• Resource Group: ${RESOURCE_GROUP}<br>• Web App URL: <a href='${WEBAPP_URL}'>${WEBAPP_URL}</a><br>• Test Suite: ${TEST_SUITE_NAME}<br>• Test Report: <a href='${TEST_REPORT_URL}'>View Report</a></p><p><strong>Configuration:</strong> ${CONFIG_LABEL}</p><p><strong>Run URL:</strong> <a href='${RUN_URL}'>${RUN_URL}</a></p><p>Please investigate the matter at your earliest convenience.</p><p>Best regards,<br>Your Automation Team</p>",
-            "subject": "[CI/CD-Automation] [${ACCELERATOR_NAME}] E2E Test-Failed"
+            "subject": "❌[CI/CD-Automation] [${ACCELERATOR_NAME}] E2E Test-Failed"
           }
           EOF
           )
@@ -272,7 +272,7 @@ jobs:
           EMAIL_BODY=$(cat <<EOF
           {
             "body": "<p>Dear Team,</p><p>The ${ACCELERATOR_NAME} pipeline executed against the <strong>specified Target URL</strong> and test automation has completed successfully.</p><p><strong>Status Summary:</strong><br><table border='1' cellpadding='5' cellspacing='0'><tr><th>Stage</th><th>Status</th></tr><tr><td>Deployment</td><td>⏭️ SKIPPED (Tests executed on Pre-deployed RG)</td></tr><tr><td>E2E Tests</td><td>✅ SUCCESS</td></tr><tr><td>Cleanup</td><td>${CLEANUP_STATUS}</td></tr></table></p><p><strong>Test Results:</strong><br>• Test Suite: ${TEST_SUITE_NAME}<br>${TEST_REPORT_URL:+• Test Report: <a href='${TEST_REPORT_URL}'>View Report</a>}<br>• Target URL: <a href='${EXISTING_URL}'>${EXISTING_URL}</a></p><p><strong>Run URL:</strong> <a href='${RUN_URL}'>${RUN_URL}</a></p><p>Best regards,<br>Your Automation Team</p>",
-            "subject": "[CI/CD-Automation] [${ACCELERATOR_NAME}] Success"
+            "subject": "✅[CI/CD-Automation] [${ACCELERATOR_NAME}] Success"
           }
           EOF
           )
@@ -302,7 +302,7 @@ jobs:
           EMAIL_BODY=$(cat <<EOF
           {
             "body": "<p>Dear Team,</p><p>The ${ACCELERATOR_NAME} pipeline executed against the <strong>specified Target URL</strong> and test automation has failed.</p><p><strong>Status Summary:</strong><br><table border='1' cellpadding='5' cellspacing='0'><tr><th>Stage</th><th>Status</th></tr><tr><td>Deployment</td><td>⏭️ SKIPPED (Tests executed on Pre-deployed RG)</td></tr><tr><td>E2E Tests</td><td>❌ FAILED</td></tr><tr><td>Cleanup</td><td>${CLEANUP_STATUS}</td></tr></table></p><p><strong>Failure Details:</strong><br>• Target URL: <a href='${EXISTING_URL}'>${EXISTING_URL}</a><br>${TEST_REPORT_URL:+• Test Report: <a href='${TEST_REPORT_URL}'>View Report</a>}<br>• Test Suite: ${TEST_SUITE_NAME}</p><p><strong>Run URL:</strong> <a href='${RUN_URL}'>${RUN_URL}</a></p><p>Best regards,<br>Your Automation Team</p>",
-            "subject": "[CI/CD-Automation] [${ACCELERATOR_NAME}] E2E Test-Failed"
+            "subject": "❌[CI/CD-Automation] [${ACCELERATOR_NAME}] E2E Test-Failed"
           }
           EOF
           )

--- a/.github/workflows/job-send-notification.yml
+++ b/.github/workflows/job-send-notification.yml
@@ -1,4 +1,5 @@
 name: Send Notification Job
+
 on:
   workflow_call:
     inputs:
@@ -32,7 +33,8 @@ on:
         type: string
       e2e_test_result:
         description: 'E2E test job result (success, failure, skipped)'
-        required: true
+        required: false
+        default: ''
         type: string
       CONTAINER_WEB_APPURL:
         description: 'Container Web App URL'
@@ -59,6 +61,11 @@ on:
         required: false
         default: ''
         type: string
+      cleanup_result:
+        description: 'Cleanup job result (success, failure, skipped)'
+        required: false
+        default: 'skipped'
+        type: string
 
 env:
   GPT_MIN_CAPACITY: 100
@@ -74,162 +81,6 @@ jobs:
     env:
       accelerator_name: "Code Modernization"
     steps:
-      - name: Validate Workflow Input Parameters
-        shell: bash
-        env:
-          INPUT_TRIGGER_TYPE: ${{ inputs.trigger_type }}
-          INPUT_WAF_ENABLED: ${{ inputs.waf_enabled }}
-          INPUT_EXP: ${{ inputs.EXP }}
-          INPUT_RUN_E2E_TESTS: ${{ inputs.run_e2e_tests }}
-          INPUT_EXISTING_WEBAPP_URL: ${{ inputs.existing_webapp_url }}
-          INPUT_DEPLOY_RESULT: ${{ inputs.deploy_result }}
-          INPUT_E2E_TEST_RESULT: ${{ inputs.e2e_test_result }}
-          INPUT_CONTAINER_WEB_APPURL: ${{ inputs.CONTAINER_WEB_APPURL }}
-          INPUT_RESOURCE_GROUP_NAME: ${{ inputs.RESOURCE_GROUP_NAME }}
-          INPUT_QUOTA_FAILED: ${{ inputs.QUOTA_FAILED }}
-          INPUT_TEST_SUCCESS: ${{ inputs.TEST_SUCCESS }}
-          INPUT_TEST_REPORT_URL: ${{ inputs.TEST_REPORT_URL }}
-        run: |
-          echo "🔍 Validating workflow input parameters..."
-          VALIDATION_FAILED=false
-          
-          # Validate trigger_type (required - alphanumeric with underscores)
-          if [[ -z "$INPUT_TRIGGER_TYPE" ]]; then
-            echo "❌ ERROR: trigger_type is required but was not provided"
-            VALIDATION_FAILED=true
-          elif [[ ! "$INPUT_TRIGGER_TYPE" =~ ^[a-zA-Z0-9_]+$ ]]; then
-            echo "❌ ERROR: trigger_type '$INPUT_TRIGGER_TYPE' is invalid. Must contain only alphanumeric characters and underscores"
-            VALIDATION_FAILED=true
-          else
-            echo "✅ trigger_type: '$INPUT_TRIGGER_TYPE' is valid"
-          fi
-          
-          # Validate waf_enabled (boolean)
-          if [[ "$INPUT_WAF_ENABLED" != "true" && "$INPUT_WAF_ENABLED" != "false" ]]; then
-            echo "❌ ERROR: waf_enabled must be 'true' or 'false', got: '$INPUT_WAF_ENABLED'"
-            VALIDATION_FAILED=true
-          else
-            echo "✅ waf_enabled: '$INPUT_WAF_ENABLED' is valid"
-          fi
-          
-          # Validate EXP (boolean)
-          if [[ "$INPUT_EXP" != "true" && "$INPUT_EXP" != "false" ]]; then
-            echo "❌ ERROR: EXP must be 'true' or 'false', got: '$INPUT_EXP'"
-            VALIDATION_FAILED=true
-          else
-            echo "✅ EXP: '$INPUT_EXP' is valid"
-          fi
-          
-          # Validate run_e2e_tests (specific allowed values)
-          if [[ -n "$INPUT_RUN_E2E_TESTS" ]]; then
-            ALLOWED_VALUES=("None" "GoldenPath-Testing" "Smoke-Testing")
-            if [[ ! " ${ALLOWED_VALUES[@]} " =~ " ${INPUT_RUN_E2E_TESTS} " ]]; then
-              echo "❌ ERROR: run_e2e_tests '$INPUT_RUN_E2E_TESTS' is invalid. Allowed values: ${ALLOWED_VALUES[*]}"
-              VALIDATION_FAILED=true
-            else
-              echo "✅ run_e2e_tests: '$INPUT_RUN_E2E_TESTS' is valid"
-            fi
-          fi
-          
-          # Validate existing_webapp_url (must start with https if provided)
-          if [[ -n "$INPUT_EXISTING_WEBAPP_URL" ]]; then
-            if [[ ! "$INPUT_EXISTING_WEBAPP_URL" =~ ^https:// ]]; then
-              echo "❌ ERROR: existing_webapp_url must start with 'https://', got: '$INPUT_EXISTING_WEBAPP_URL'"
-              VALIDATION_FAILED=true
-            else
-              echo "✅ existing_webapp_url: '$INPUT_EXISTING_WEBAPP_URL' is valid"
-            fi
-          fi
-          
-          # Validate deploy_result (required, must be specific values)
-          if [[ -z "$INPUT_DEPLOY_RESULT" ]]; then
-            echo "❌ ERROR: deploy_result is required but not provided"
-            VALIDATION_FAILED=true
-          else
-            ALLOWED_DEPLOY_RESULTS=("success" "failure" "skipped")
-            if [[ ! " ${ALLOWED_DEPLOY_RESULTS[@]} " =~ " ${INPUT_DEPLOY_RESULT} " ]]; then
-              echo "❌ ERROR: deploy_result '$INPUT_DEPLOY_RESULT' is invalid. Allowed values: ${ALLOWED_DEPLOY_RESULTS[*]}"
-              VALIDATION_FAILED=true
-            else
-              echo "✅ deploy_result: '$INPUT_DEPLOY_RESULT' is valid"
-            fi
-          fi
-          
-          # Validate e2e_test_result (required, must be specific values)
-          if [[ -z "$INPUT_E2E_TEST_RESULT" ]]; then
-            echo "❌ ERROR: e2e_test_result is required but not provided"
-            VALIDATION_FAILED=true
-          else
-            ALLOWED_TEST_RESULTS=("success" "failure" "skipped")
-            if [[ ! " ${ALLOWED_TEST_RESULTS[@]} " =~ " ${INPUT_E2E_TEST_RESULT} " ]]; then
-              echo "❌ ERROR: e2e_test_result '$INPUT_E2E_TEST_RESULT' is invalid. Allowed values: ${ALLOWED_TEST_RESULTS[*]}"
-              VALIDATION_FAILED=true
-            else
-              echo "✅ e2e_test_result: '$INPUT_E2E_TEST_RESULT' is valid"
-            fi
-          fi
-          
-          # Validate CONTAINER_WEB_APPURL (must start with https if provided)
-          if [[ -n "$INPUT_CONTAINER_WEB_APPURL" ]]; then
-            if [[ ! "$INPUT_CONTAINER_WEB_APPURL" =~ ^https:// ]]; then
-              echo "❌ ERROR: CONTAINER_WEB_APPURL must start with 'https://', got: '$INPUT_CONTAINER_WEB_APPURL'"
-              VALIDATION_FAILED=true
-            else
-              echo "✅ CONTAINER_WEB_APPURL: '$INPUT_CONTAINER_WEB_APPURL' is valid"
-            fi
-          fi
-          
-          # Validate RESOURCE_GROUP_NAME (Azure resource group naming convention if provided)
-          if [[ -n "$INPUT_RESOURCE_GROUP_NAME" ]]; then
-            if [[ ! "$INPUT_RESOURCE_GROUP_NAME" =~ ^[a-zA-Z0-9._\(\)-]+$ ]] || [[ "$INPUT_RESOURCE_GROUP_NAME" =~ \.$ ]]; then
-              echo "❌ ERROR: RESOURCE_GROUP_NAME '$INPUT_RESOURCE_GROUP_NAME' is invalid. Must contain only alphanumerics, periods, underscores, hyphens, and parentheses. Cannot end with period."
-              VALIDATION_FAILED=true
-            elif [[ ${#INPUT_RESOURCE_GROUP_NAME} -gt 90 ]]; then
-              echo "❌ ERROR: RESOURCE_GROUP_NAME '$INPUT_RESOURCE_GROUP_NAME' exceeds 90 characters"
-              VALIDATION_FAILED=true
-            else
-              echo "✅ RESOURCE_GROUP_NAME: '$INPUT_RESOURCE_GROUP_NAME' is valid"
-            fi
-          fi
-          
-          # Validate QUOTA_FAILED (must be 'true', 'false', or empty string)
-          if [[ "$INPUT_QUOTA_FAILED" != "true" && "$INPUT_QUOTA_FAILED" != "false" && "$INPUT_QUOTA_FAILED" != "" ]]; then
-            echo "❌ ERROR: QUOTA_FAILED must be 'true', 'false', or empty string, got: '$INPUT_QUOTA_FAILED'"
-            VALIDATION_FAILED=true
-          else
-            echo "✅ QUOTA_FAILED: '$INPUT_QUOTA_FAILED' is valid"
-          fi
-          
-          # Validate TEST_SUCCESS (must be 'true' or 'false' or empty)
-          if [[ -n "$INPUT_TEST_SUCCESS" ]]; then
-            if [[ "$INPUT_TEST_SUCCESS" != "true" && "$INPUT_TEST_SUCCESS" != "false" ]]; then
-              echo "❌ ERROR: TEST_SUCCESS must be 'true', 'false', or empty, got: '$INPUT_TEST_SUCCESS'"
-              VALIDATION_FAILED=true
-            else
-              echo "✅ TEST_SUCCESS: '$INPUT_TEST_SUCCESS' is valid"
-            fi
-          fi
-          
-          # Validate TEST_REPORT_URL (must start with https if provided)
-          if [[ -n "$INPUT_TEST_REPORT_URL" ]]; then
-            if [[ ! "$INPUT_TEST_REPORT_URL" =~ ^https:// ]]; then
-              echo "❌ ERROR: TEST_REPORT_URL must start with 'https://', got: '$INPUT_TEST_REPORT_URL'"
-              VALIDATION_FAILED=true
-            else
-              echo "✅ TEST_REPORT_URL: '$INPUT_TEST_REPORT_URL' is valid"
-            fi
-          fi
-          
-          # Fail workflow if any validation failed
-          if [[ "$VALIDATION_FAILED" == "true" ]]; then
-            echo ""
-            echo "❌ Parameter validation failed. Please correct the errors above and try again."
-            exit 1
-          fi
-          
-          echo ""
-          echo "✅ All input parameters validated successfully!"
-          
       - name: Determine Test Suite Display Name
         id: test_suite
         shell: bash
@@ -248,6 +99,29 @@ jobs:
           echo "TEST_SUITE_NAME=$TEST_SUITE_NAME" >> $GITHUB_OUTPUT
           echo "Test Suite: $TEST_SUITE_NAME"
 
+      - name: Determine Cleanup Status
+        id: cleanup
+        shell: bash
+        env:
+          CLEANUP_RESULT: ${{ inputs.cleanup_result }}
+        run: |
+          case "$CLEANUP_RESULT" in
+            success) echo "CLEANUP_STATUS=✅ SUCCESS" >> $GITHUB_OUTPUT ;;
+            failure) echo "CLEANUP_STATUS=❌ FAILED (Needs Manual Cleanup)" >> $GITHUB_OUTPUT ;;
+            *) echo "CLEANUP_STATUS=⏭️ SKIPPED (Needs Manual Cleanup)" >> $GITHUB_OUTPUT ;;
+          esac
+
+      - name: Determine Configuration Label
+        id: config
+        shell: bash
+        env:
+          WAF_ENABLED: ${{ env.WAF_ENABLED }}
+          EXP: ${{ env.EXP }}
+        run: |
+          WAF_LABEL=$( [ "$WAF_ENABLED" = "true" ] && echo "WAF" || echo "Non-WAF" )
+          EXP_LABEL=$( [ "$EXP" = "true" ] && echo "EXP" || echo "Non-EXP" )
+          echo "CONFIG_LABEL=${WAF_LABEL} + ${EXP_LABEL}" >> $GITHUB_OUTPUT
+
       - name: Send Quota Failure Notification
         if: inputs.deploy_result == 'failure' && inputs.QUOTA_FAILED == 'true'
         shell: bash
@@ -256,12 +130,14 @@ jobs:
           GITHUB_RUN_ID: ${{ github.run_id }}
           ACCELERATOR_NAME: ${{ env.accelerator_name }}
           LOGICAPP_URL: ${{ secrets.EMAILNOTIFICATION_LOGICAPP_URL_TA }}
+          CLEANUP_STATUS: ${{ steps.cleanup.outputs.CLEANUP_STATUS }}
+          CONFIG_LABEL: ${{ steps.config.outputs.CONFIG_LABEL }}
         run: |
-          RUN_URL="https://github.com/${GITHUB_REPOSITORY }/actions/runs/${GITHUB_RUN_ID}"
+          RUN_URL="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           EMAIL_BODY=$(cat <<EOF
           {
-            "body": "<p>Dear Team,</p><p>We would like to inform you that the ${ACCELERATOR_NAME} deployment has failed due to insufficient quota in the requested regions.</p><p><strong>Issue Details:</strong><br>• Quota check failed for GPT model<br>• Required GPT Capacity: ${{ env.GPT_MIN_CAPACITY }}<br>• Checked Regions: ${{ vars.AZURE_REGIONS }}</p><p><strong>Run URL:</strong> <a href='${RUN_URL}'>${RUN_URL}</a></p><p>Please resolve the quota issue and retry the deployment.</p><p>Best regards,<br>Your Automation Team</p>",
-            "subject": "${ACCELERATOR_NAME} Pipeline - Failed (Insufficient Quota)"
+            "body": "<p>Dear Team,</p><p>We would like to inform you that the ${ACCELERATOR_NAME} deployment has failed due to insufficient quota.</p><p><strong>Status Summary:</strong><br><table border='1' cellpadding='5' cellspacing='0'><tr><th>Stage</th><th>Status</th></tr><tr><td>Deployment</td><td>❌ FAILED (Insufficient Quota)</td></tr><tr><td>E2E Tests</td><td>⏭️ SKIPPED</td></tr><tr><td>Cleanup</td><td>${CLEANUP_STATUS}</td></tr></table></p><p><strong>Configuration:</strong> ${CONFIG_LABEL}</p><p><strong>Run URL:</strong> <a href='${RUN_URL}'>${RUN_URL}</a></p><p>Please resolve the quota issue and retry the deployment.</p><p>Best regards,<br>Your Automation Team</p>",
+            "subject": "[CI/CD-Automation] [${ACCELERATOR_NAME}] Insufficient Quota"
           }
           EOF
           )
@@ -277,16 +153,16 @@ jobs:
           INPUT_RESOURCE_GROUP_NAME: ${{ inputs.RESOURCE_GROUP_NAME }}
           ACCELERATOR_NAME: ${{ env.accelerator_name }}
           LOGICAPP_URL: ${{ secrets.EMAILNOTIFICATION_LOGICAPP_URL_TA }}
-          WAF_ENABLED: ${{ env.WAF_ENABLED }}
-          EXP: ${{ env.EXP }}
+          CONFIG_LABEL: ${{ steps.config.outputs.CONFIG_LABEL }}
+          CLEANUP_STATUS: ${{ steps.cleanup.outputs.CLEANUP_STATUS }}
         run: |
           RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           RESOURCE_GROUP="$INPUT_RESOURCE_GROUP_NAME"
           
           EMAIL_BODY=$(cat <<EOF
           {
-            "body": "<p>Dear Team,</p><p>We would like to inform you that the ${ACCELERATOR_NAME} deployment process has encountered an issue and has failed to complete successfully.</p><p><strong>Deployment Details:</strong><br>• Resource Group: ${RESOURCE_GROUP}<br>• WAF Enabled: ${WAF_ENABLED}<br>• EXP Enabled: ${EXP}</p><p><strong>Run URL:</strong> <a href='${RUN_URL}'>${RUN_URL}</a></p><p>Please investigate the deployment failure at your earliest convenience.</p><p>Best regards,<br>Your Automation Team</p>",
-            "subject": "${ACCELERATOR_NAME} Pipeline - Failed"
+            "body": "<p>Dear Team,</p><p>We would like to inform you that the ${ACCELERATOR_NAME} deployment has failed.</p><p><strong>Status Summary:</strong><br><table border='1' cellpadding='5' cellspacing='0'><tr><th>Stage</th><th>Status</th></tr><tr><td>Deployment</td><td>❌ FAILED (Deployment Issue)</td></tr><tr><td>E2E Tests</td><td>⏭️ SKIPPED</td></tr><tr><td>Cleanup</td><td>${CLEANUP_STATUS}</td></tr></table></p><p><strong>Deployment Details:</strong><br>• Resource Group: ${RESOURCE_GROUP}</p><p><strong>Configuration:</strong> ${CONFIG_LABEL}</p><p><strong>Run URL:</strong> <a href='${RUN_URL}'>${RUN_URL}</a></p><p>Please investigate the deployment failure at your earliest convenience.</p><p>Best regards,<br>Your Automation Team</p>",
+            "subject": "[CI/CD-Automation] [${ACCELERATOR_NAME}] Deployment-Failed"
           }
           EOF
           )
@@ -308,29 +184,30 @@ jobs:
           LOGICAPP_URL: ${{ secrets.EMAILNOTIFICATION_LOGICAPP_URL_TA }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_RUN_ID: ${{ github.run_id }}
-          EXP: ${{ env.EXP }}
-          WAF_ENABLED: ${{ env.WAF_ENABLED }}
+          CONFIG_LABEL: ${{ steps.config.outputs.CONFIG_LABEL }}
+          CLEANUP_STATUS: ${{ steps.cleanup.outputs.CLEANUP_STATUS }}
+          RUN_E2E_TESTS: ${{ env.RUN_E2E_TESTS }}
+          TEST_SUITE_NAME: ${{ steps.test_suite.outputs.TEST_SUITE_NAME }}
           
         run: |
           RUN_URL="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           WEBAPP_URL="${INPUT_CONTAINER_WEB_APPURL:-$INPUT_EXISTING_WEBAPP_URL}"
           RESOURCE_GROUP="$INPUT_RESOURCE_GROUP_NAME"
           TEST_REPORT_URL="$INPUT_TEST_REPORT_URL"
-          TEST_SUITE_NAME="${{ steps.test_suite.outputs.TEST_SUITE_NAME }}"
           
           if [ "$INPUT_E2E_TEST_RESULT" = "skipped" ]; then
             EMAIL_BODY=$(cat <<EOF
           {
-            "body": "<p>Dear Team,</p><p>We would like to inform you that the ${ACCELERATOR_NAME} deployment has completed successfully.</p><p><strong>Deployment Details:</strong><br>• Resource Group: ${RESOURCE_GROUP}<br>• Web App URL: <a href='${WEBAPP_URL}'>${WEBAPP_URL}</a><br>• E2E Tests: Skipped (as configured)</p><p><strong>Configuration:</strong><br>• WAF Enabled: ${WAF_ENABLED}<br>• EXP Enabled: ${EXP}</p><p><strong>Run URL:</strong> <a href='${RUN_URL}'>${RUN_URL}</a></p><p>Best regards,<br>Your Automation Team</p>",
-            "subject": "${ACCELERATOR_NAME} Pipeline - Deployment Success"
+            "body": "<p>Dear Team,</p><p>We would like to inform you that the ${ACCELERATOR_NAME} deployment has completed successfully.</p><p><strong>Status Summary:</strong><br><table border='1' cellpadding='5' cellspacing='0'><tr><th>Stage</th><th>Status</th></tr><tr><td>Deployment</td><td>✅ SUCCESS</td></tr><tr><td>E2E Tests</td><td>⏭️ SKIPPED</td></tr><tr><td>Cleanup</td><td>${CLEANUP_STATUS}</td></tr></table></p><p><strong>Deployment Details:</strong><br>• Resource Group: ${RESOURCE_GROUP}<br>• Web App URL: <a href='${WEBAPP_URL}'>${WEBAPP_URL}</a></p><p><strong>Configuration:</strong> ${CONFIG_LABEL}</p><p><strong>Run URL:</strong> <a href='${RUN_URL}'>${RUN_URL}</a></p><p>Best regards,<br>Your Automation Team</p>",
+            "subject": "[CI/CD-Automation] [${ACCELERATOR_NAME}] Success"
           }
           EOF
             )
           else
             EMAIL_BODY=$(cat <<EOF
           {
-            "body": "<p>Dear Team,</p><p>We would like to inform you that the ${ACCELERATOR_NAME} deployment and testing process has completed successfully.</p><p><strong>Deployment Details:</strong><br>• Resource Group: ${RESOURCE_GROUP}<br>• Web App URL: <a href='${WEBAPP_URL}'>${WEBAPP_URL}</a><br>• E2E Tests: Passed ✅<br>• Test Suite: ${TEST_SUITE_NAME}<br>• Test Report: <a href='${TEST_REPORT_URL}'>View Report</a></p><p><strong>Configuration:</strong><br>• WAF Enabled: ${WAF_ENABLED}<br>• EXP Enabled: ${EXP}</p><p><strong>Run URL:</strong> <a href='${RUN_URL}'>${RUN_URL}</a></p><p>Best regards,<br>Your Automation Team</p>",
-            "subject": "${ACCELERATOR_NAME} Pipeline - Test Automation - Success"
+            "body": "<p>Dear Team,</p><p>We would like to inform you that the ${ACCELERATOR_NAME} deployment and test automation has completed successfully.</p><p><strong>Status Summary:</strong><br><table border='1' cellpadding='5' cellspacing='0'><tr><th>Stage</th><th>Status</th></tr><tr><td>Deployment</td><td>✅ SUCCESS</td></tr><tr><td>E2E Tests</td><td>✅ SUCCESS</td></tr><tr><td>Cleanup</td><td>${CLEANUP_STATUS}</td></tr></table></p><p><strong>Deployment Details:</strong><br>• Resource Group: ${RESOURCE_GROUP}<br>• Web App URL: <a href='${WEBAPP_URL}'>${WEBAPP_URL}</a><br>• Test Suite: ${TEST_SUITE_NAME}<br>• Test Report: <a href='${TEST_REPORT_URL}'>View Report</a></p><p><strong>Configuration:</strong> ${CONFIG_LABEL}</p><p><strong>Run URL:</strong> <a href='${RUN_URL}'>${RUN_URL}</a></p><p>Best regards,<br>Your Automation Team</p>",
+            "subject": "[CI/CD-Automation] [${ACCELERATOR_NAME}] Success"
           }
           EOF
             )
@@ -351,18 +228,21 @@ jobs:
           INPUT_RESOURCE_GROUP_NAME: ${{ inputs.RESOURCE_GROUP_NAME }}
           ACCELERATOR_NAME: ${{ env.accelerator_name }}
           LOGICAPP_URL: ${{ secrets.EMAILNOTIFICATION_LOGICAPP_URL_TA }}
+          CLEANUP_STATUS: ${{ steps.cleanup.outputs.CLEANUP_STATUS }}
+          CONFIG_LABEL: ${{ steps.config.outputs.CONFIG_LABEL }}
+          RUN_E2E_TESTS: ${{ env.RUN_E2E_TESTS }}
+          TEST_SUITE_NAME: ${{ steps.test_suite.outputs.TEST_SUITE_NAME }}
           INPUT_TEST_REPORT_URL: ${{ inputs.TEST_REPORT_URL }}
         run: |
           RUN_URL="https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}"
           TEST_REPORT_URL="$INPUT_TEST_REPORT_URL"
           WEBAPP_URL="${INPUT_CONTAINER_WEB_APPURL:-$INPUT_EXISTING_WEBAPP_URL}"
           RESOURCE_GROUP="$INPUT_RESOURCE_GROUP_NAME"
-          TEST_SUITE_NAME="${{ steps.test_suite.outputs.TEST_SUITE_NAME }}"
           
           EMAIL_BODY=$(cat <<EOF
           {
-            "body": "<p>Dear Team,</p><p>We would like to inform you that ${ACCELERATOR_NAME} accelerator test automation process has encountered issues and failed to complete successfully.</p><p><strong>Deployment Details:</strong><br>• Resource Group: ${RESOURCE_GROUP}<br>• Web App URL: <a href='${WEBAPP_URL}'>${WEBAPP_URL}</a><br>• Deployment Status: ✅ Success<br>• E2E Tests: ❌ Failed<br>• Test Suite: ${TEST_SUITE_NAME}</p><p><strong>Test Details:</strong><br>• Test Report: <a href='${TEST_REPORT_URL}'>View Report</a></p><p><strong>Run URL:</strong> <a href='${RUN_URL}'>${RUN_URL}</a></p><p>Please investigate the matter at your earliest convenience.</p><p>Best regards,<br>Your Automation Team</p>",
-            "subject": "${ACCELERATOR_NAME} Pipeline - Test Automation - Failed"
+            "body": "<p>Dear Team,</p><p>We would like to inform you that ${ACCELERATOR_NAME} test automation has failed.</p><p><strong>Status Summary:</strong><br><table border='1' cellpadding='5' cellspacing='0'><tr><th>Stage</th><th>Status</th></tr><tr><td>Deployment</td><td>✅ SUCCESS</td></tr><tr><td>E2E Tests</td><td>❌ FAILED</td></tr><tr><td>Cleanup</td><td>${CLEANUP_STATUS}</td></tr></table></p><p><strong>Deployment Details:</strong><br>• Resource Group: ${RESOURCE_GROUP}<br>• Web App URL: <a href='${WEBAPP_URL}'>${WEBAPP_URL}</a><br>• Test Suite: ${TEST_SUITE_NAME}<br>• Test Report: <a href='${TEST_REPORT_URL}'>View Report</a></p><p><strong>Configuration:</strong> ${CONFIG_LABEL}</p><p><strong>Run URL:</strong> <a href='${RUN_URL}'>${RUN_URL}</a></p><p>Please investigate the matter at your earliest convenience.</p><p>Best regards,<br>Your Automation Team</p>",
+            "subject": "[CI/CD-Automation] [${ACCELERATOR_NAME}] E2E Test-Failed"
           }
           EOF
           )
@@ -381,16 +261,18 @@ jobs:
           INPUT_TEST_REPORT_URL: ${{ inputs.TEST_REPORT_URL }}
           ACCELERATOR_NAME: ${{ env.accelerator_name }}
           LOGICAPP_URL: ${{ secrets.EMAILNOTIFICATION_LOGICAPP_URL_TA }}
+          CLEANUP_STATUS: ${{ steps.cleanup.outputs.CLEANUP_STATUS }}
+          RUN_E2E_TESTS: ${{ env.RUN_E2E_TESTS }}
+          TEST_SUITE_NAME: ${{ steps.test_suite.outputs.TEST_SUITE_NAME }}
         run: |
           RUN_URL="https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}"
           EXISTING_URL="$INPUT_EXISTING_WEBAPP_URL"
           TEST_REPORT_URL="$INPUT_TEST_REPORT_URL"
-          TEST_SUITE_NAME="${{ steps.test_suite.outputs.TEST_SUITE_NAME }}"
           
           EMAIL_BODY=$(cat <<EOF
           {
-            "body": "<p>Dear Team,</p><p>The ${ACCELERATOR_NAME} pipeline executed against the <strong>specified Target URL</strong> and testing process has completed successfully.</p><p><strong>Test Results:</strong><br>• Status: ✅ Passed<br>• Test Suite: ${TEST_SUITE_NAME}<br>${TEST_REPORT_URL:+• Test Report: <a href='${TEST_REPORT_URL}'>View Report</a>}<br>• Target URL: <a href='${EXISTING_URL}'>${EXISTING_URL}</a></p><p><strong>Deployment:</strong> Skipped</p><p><strong>Run URL:</strong> <a href='${RUN_URL}'>${RUN_URL}</a></p><p>Best regards,<br>Your Automation Team</p>",
-            "subject": "${ACCELERATOR_NAME} Pipeline - Test Automation Passed "
+            "body": "<p>Dear Team,</p><p>The ${ACCELERATOR_NAME} pipeline executed against the <strong>specified Target URL</strong> and test automation has completed successfully.</p><p><strong>Status Summary:</strong><br><table border='1' cellpadding='5' cellspacing='0'><tr><th>Stage</th><th>Status</th></tr><tr><td>Deployment</td><td>⏭️ SKIPPED (Tests executed on Pre-deployed RG)</td></tr><tr><td>E2E Tests</td><td>✅ SUCCESS</td></tr><tr><td>Cleanup</td><td>${CLEANUP_STATUS}</td></tr></table></p><p><strong>Test Results:</strong><br>• Test Suite: ${TEST_SUITE_NAME}<br>${TEST_REPORT_URL:+• Test Report: <a href='${TEST_REPORT_URL}'>View Report</a>}<br>• Target URL: <a href='${EXISTING_URL}'>${EXISTING_URL}</a></p><p><strong>Run URL:</strong> <a href='${RUN_URL}'>${RUN_URL}</a></p><p>Best regards,<br>Your Automation Team</p>",
+            "subject": "[CI/CD-Automation] [${ACCELERATOR_NAME}] Success"
           }
           EOF
           )
@@ -409,16 +291,18 @@ jobs:
           INPUT_TEST_REPORT_URL: ${{ inputs.TEST_REPORT_URL }}
           ACCELERATOR_NAME: ${{ env.accelerator_name }}
           LOGICAPP_URL: ${{ secrets.EMAILNOTIFICATION_LOGICAPP_URL_TA }}
+          CLEANUP_STATUS: ${{ steps.cleanup.outputs.CLEANUP_STATUS }}
+          RUN_E2E_TESTS: ${{ env.RUN_E2E_TESTS }}
+          TEST_SUITE_NAME: ${{ steps.test_suite.outputs.TEST_SUITE_NAME }}
         run: |
           RUN_URL="https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}"
           EXISTING_URL="$INPUT_EXISTING_WEBAPP_URL"
           TEST_REPORT_URL="$INPUT_TEST_REPORT_URL"
-          TEST_SUITE_NAME="${{ steps.test_suite.outputs.TEST_SUITE_NAME }}"
           
           EMAIL_BODY=$(cat <<EOF
           {
-            "body": "<p>Dear Team,</p><p>The ${ACCELERATOR_NAME} pipeline executed against the <strong>specified Target URL</strong> and the test automation has encountered issues and failed to complete successfully.</p><p><strong>Failure Details:</strong><br>• Target URL: <a href='${EXISTING_URL}'>${EXISTING_URL}</a><br>${TEST_REPORT_URL:+• Test Report: <a href='${TEST_REPORT_URL}'>View Report</a>}<br>• Test Suite: ${TEST_SUITE_NAME}<br>• Deployment: Skipped</p><p><strong>Run URL:</strong> <a href='${RUN_URL}'>${RUN_URL}</a></p><p>Best regards,<br>Your Automation Team</p>",
-            "subject": "${ACCELERATOR_NAME} Pipeline - Test Automation Failed "
+            "body": "<p>Dear Team,</p><p>The ${ACCELERATOR_NAME} pipeline executed against the <strong>specified Target URL</strong> and test automation has failed.</p><p><strong>Status Summary:</strong><br><table border='1' cellpadding='5' cellspacing='0'><tr><th>Stage</th><th>Status</th></tr><tr><td>Deployment</td><td>⏭️ SKIPPED (Tests executed on Pre-deployed RG)</td></tr><tr><td>E2E Tests</td><td>❌ FAILED</td></tr><tr><td>Cleanup</td><td>${CLEANUP_STATUS}</td></tr></table></p><p><strong>Failure Details:</strong><br>• Target URL: <a href='${EXISTING_URL}'>${EXISTING_URL}</a><br>${TEST_REPORT_URL:+• Test Report: <a href='${TEST_REPORT_URL}'>View Report</a>}<br>• Test Suite: ${TEST_SUITE_NAME}</p><p><strong>Run URL:</strong> <a href='${RUN_URL}'>${RUN_URL}</a></p><p>Best regards,<br>Your Automation Team</p>",
+            "subject": "[CI/CD-Automation] [${ACCELERATOR_NAME}] E2E Test-Failed"
           }
           EOF
           )


### PR DESCRIPTION
## Purpose
This pull request updates the deployment and notification workflows to improve reporting on the cleanup process and enhance the clarity of notification emails. The changes introduce explicit tracking of the cleanup job's result, add configuration labeling, and provide a more detailed status summary in notification messages.

Key changes include:

**Workflow Orchestration Improvements:**
- Added a `cleanup-deployment` job to `.github/workflows/deploy-orchestrator.yml`, which runs after deployment and testing, and passes its result to the notification job. The notification job now depends on the cleanup job and receives its outcome as an input. [[1]](diffhunk://#diff-d13e946b411762697bc3a5825b5350445fa0296d5c1b1489776f7b82a84dfca4R105-R123) [[2]](diffhunk://#diff-d13e946b411762697bc3a5825b5350445fa0296d5c1b1489776f7b82a84dfca4L122-R138)

**Notification Job Enhancements:**
- Modified `.github/workflows/job-send-notification.yml` to accept and process a new `cleanup_result` input, with logic to determine and format the cleanup status for email summaries. [[1]](diffhunk://#diff-f63b15a32fa412295c3d660104505c6a2345b066844d2ba99d182458e9f5cc76R64-R68) [[2]](diffhunk://#diff-f63b15a32fa412295c3d660104505c6a2345b066844d2ba99d182458e9f5cc76R102-R124)
- Added a step to generate a configuration label (e.g., "WAF + EXP") for inclusion in notifications.

**Notification Content Updates:**
- All notification emails now include a status summary table showing the outcome of Deployment, E2E Tests, and Cleanup, as well as the configuration label. Subjects and body content have been updated for clarity and consistency. [[1]](diffhunk://#diff-f63b15a32fa412295c3d660104505c6a2345b066844d2ba99d182458e9f5cc76R133-R140) [[2]](diffhunk://#diff-f63b15a32fa412295c3d660104505c6a2345b066844d2ba99d182458e9f5cc76L280-R165) [[3]](diffhunk://#diff-f63b15a32fa412295c3d660104505c6a2345b066844d2ba99d182458e9f5cc76L311-R210) [[4]](diffhunk://#diff-f63b15a32fa412295c3d660104505c6a2345b066844d2ba99d182458e9f5cc76R231-R245)

**Input Handling and Validation:**
- Made the `e2e_test_result` input optional (with a default value) to support cases where E2E tests may be skipped.

**Codebase Simplification:**
- Removed the extensive "Validate Workflow Input Parameters" step from the notification job, streamlining the workflow and reducing redundancy.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.