### PR TITLE
feat: Add pytest coverage comment to PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,7 @@ name: Test Workflow with Coverage - Code-Gen
 permissions:
   contents: read
   actions: read
+  pull-requests: write
 on:
   push:
     branches:
@@ -112,9 +113,21 @@ jobs:
         if: env.skip_backend_tests == 'false'
         run: |
           cd src
-          pytest tests/backend --cov=backend --cov-report=term-missing --cov-report=xml --cov-fail-under=80
+          pytest tests/backend --cov=backend --cov-report=term-missing --cov-report=xml --cov-fail-under=80 --junitxml=pytest.xml
 
 
+
+      - name: Pytest Coverage Comment
+        if: |
+          always() &&
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.fork == false &&
+          env.skip_backend_tests == 'false'
+        uses: MishaKav/pytest-coverage-comment@26f986d2599c288bb62f623d29c2da98609e9cd4  # v1.6.0
+        with:
+          pytest-xml-coverage-path: src/coverage.xml
+          junitxml-path: src/pytest.xml
+          report-only-changed-files: true
 
       - name: Skip Backend Tests
         if: env.skip_backend_tests == 'true'


### PR DESCRIPTION
Add MishaKav/pytest-coverage-comment action to post code coverage summary as a PR comment. Changes include:
- Add pull-requests: write permission
- Add --junitxml=pytest.xml flag for test summary
- Add coverage comment step with per-file breakdown

## Purpose
This pull request updates the GitHub Actions workflow to improve test coverage reporting on pull requests. The main changes add automated commenting of pytest coverage results directly on pull requests and adjust permissions to allow this.

**Workflow enhancements for coverage reporting:**

* Added the `pull-requests: write` permission to the workflow to enable posting comments on pull requests.
* Modified the backend test command to output a JUnit XML report (`--junitxml=pytest.xml`) for use in coverage reporting.
* Integrated the `MishaKav/pytest-coverage-comment` GitHub Action to automatically post test coverage summaries as comments on pull requests, configured to only report on changed files and only for non-forked PRs.
## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No
