### PR TITLE
fix: Infinite loading when uploaded one harmful content file

### DIFF
--- a/src/frontend/src/pages/modernizationPage.tsx
+++ b/src/frontend/src/pages/modernizationPage.tsx
@@ -1013,6 +1013,43 @@ useEffect(() => {
     return () => clearInterval(checkInactivity);
   }, [lastActivityTime, files, allFilesCompleted, updateSummaryStatus, navigate, batchId]);
 
+  // Fallback polling: periodically re-fetch batch summary to catch cases where
+  // WebSocket events were missed (e.g., all files were harmful and processed
+  // before WebSocket connected). Polls every 5 seconds until all files are done.
+  useEffect(() => {
+    if (allFilesCompleted || !batchId || hasNavigatedRef.current) return;
+
+    const pollInterval = setInterval(async () => {
+      if (hasNavigatedRef.current || allFilesCompleted) {
+        clearInterval(pollInterval);
+        return;
+      }
+      try {
+        const data = await fetchBatchSummary(batchId);
+        if (!data) return;
+
+        const batchTerminal = ["completed", "failed"].includes(data.status?.toLowerCase() || "");
+        const allTerminal = data.files.every((file: any) =>
+          ["completed", "failed", "error"].includes(file.status?.toLowerCase() || "")
+        );
+
+        if (batchTerminal || allTerminal) {
+          console.log("Fallback poll detected batch completion, navigating to batch view");
+          clearInterval(pollInterval);
+          setAllFilesCompleted(true);
+          if (!hasNavigatedRef.current) {
+            hasNavigatedRef.current = true;
+            navigate(`/batch-view/${batchId}`);
+          }
+        }
+      } catch (err) {
+        console.error("Fallback poll error:", err);
+      }
+    }, 5000);
+
+    return () => clearInterval(pollInterval);
+  }, [batchId, allFilesCompleted, navigate]);
+
 
   useEffect(() => {
     console.log('Current files state:', files);

--- a/src/frontend/src/pages/modernizationPage.tsx
+++ b/src/frontend/src/pages/modernizationPage.tsx
@@ -31,7 +31,7 @@ import { Light as SyntaxHighlighter } from "react-syntax-highlighter"
 import { vs } from "react-syntax-highlighter/dist/esm/styles/hljs"
 import sql from "react-syntax-highlighter/dist/cjs/languages/hljs/sql"
 import { useNavigate, useParams } from "react-router-dom"
-import { useState, useEffect, useCallback } from "react"
+import { useState, useEffect, useCallback, useRef } from "react"
 import { getApiUrl, headerBuilder } from '../api/config';
 import BatchHistoryPanel from "../components/batchHistoryPanel"
 import PanelRight from "../components/Panels/PanelRight";
@@ -501,6 +501,7 @@ const ModernizationPage = () => {
   const [isZipButtonDisabled, setIsZipButtonDisabled] = useState(true);
   const [fileLoading, setFileLoading] = useState(false);
   const [lastActivityTime, setLastActivityTime] = useState<number>(Date.now());
+  const hasNavigatedRef = useRef(false);
   //const [pageLoadTime] = useState<number>(Date.now());
 
   // Fetch file content when a file is selected
@@ -536,11 +537,21 @@ const ModernizationPage = () => {
       setBatchSummary(data);
       if (data) {
 
-        const batchCompleted = data.status?.toLowerCase() === "completed" || data.status === "failed";
-        if (batchCompleted) {
+        const batchCompleted = data.status?.toLowerCase() === "completed" || data.status?.toLowerCase() === "failed";
+        const allFilesTerminal = data.files.every((file: any) =>
+          ["completed", "failed", "error"].includes(file.status?.toLowerCase() || "")
+        );
+
+        if (batchCompleted || allFilesTerminal) {
           setAllFilesCompleted(true);
           if (data.hasFiles > 0) {
             setIsZipButtonDisabled(false);
+          }
+          // Batch already finished (e.g., all files were harmful content) — navigate directly
+          if (!hasNavigatedRef.current) {
+            hasNavigatedRef.current = true;
+            navigate(`/batch-view/${batchId}`);
+            return;
           }
         }
         // Transform the server response to an array of your FileItem objects
@@ -725,7 +736,10 @@ const ModernizationPage = () => {
   // Update files state when Redux fileList changes
   useEffect(() => {
     if (reduxFileList && reduxFileList.length > 0) {
-      setAllFilesCompleted(false);
+      // Only reset completion state if not already finalized
+      if (!allFilesCompleted) {
+        setAllFilesCompleted(false);
+      }
       // Map the Redux fileList to our FileItem format
       const fileItems: FileItem[] = reduxFileList.filter(file => file.type !== 'summary').map((file: any, index: number) => ({
 
@@ -832,8 +846,11 @@ const ModernizationPage = () => {
         });
 
         // Navigate only after all files have reached terminal states.
-        console.log("Processing complete (all files done), navigating to batch view page");
-        navigate(`/batch-view/${batchId}`);
+        if (!hasNavigatedRef.current) {
+          hasNavigatedRef.current = true;
+          console.log("Processing complete (all files done), navigating to batch view page");
+          navigate(`/batch-view/${batchId}`);
+        }
       }
     } catch (err) {
       console.error("Failed to update summary status:", err);


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->

This pull request improves the reliability of navigation and completion detection on the `ModernizationPage` by ensuring users are redirected to the batch view as soon as all files reach a terminal state, even if WebSocket events are missed. It introduces a fallback polling mechanism, prevents duplicate navigation, and refines how completion is detected.

**Navigation and Completion Detection Improvements:**

* Added a `useRef` (`hasNavigatedRef`) to prevent duplicate navigation to the batch view page when all files or the batch reach a terminal state. Navigation now only occurs once, even if multiple triggers fire. [[1]](diffhunk://#diff-e02a101a0cdda5e7fcb1f9e3b821ddcac27c3130fa83517f6aef9c6c0ce0aaadL34-R34) [[2]](diffhunk://#diff-e02a101a0cdda5e7fcb1f9e3b821ddcac27c3130fa83517f6aef9c6c0ce0aaadR504) [[3]](diffhunk://#diff-e02a101a0cdda5e7fcb1f9e3b821ddcac27c3130fa83517f6aef9c6c0ce0aaadL539-R555) [[4]](diffhunk://#diff-e02a101a0cdda5e7fcb1f9e3b821ddcac27c3130fa83517f6aef9c6c0ce0aaadR849-R854)
* Improved detection of batch/file completion by checking if all files have terminal statuses (`completed`, `failed`, or `error`), not just the batch status, before enabling navigation and the zip button.

**Fallback Handling and State Management:**

* Implemented a fallback polling `useEffect` that periodically fetches the batch summary every 5 seconds, ensuring navigation occurs even if WebSocket events are missed (e.g., all files are processed before the WebSocket connects).
* Updated the logic to only reset the completion state (`allFilesCompleted`) if it hasn't already been finalized, preventing unnecessary state changes.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->

