### PR TITLE
refactor: Updated Foundry Roles name

### DIFF
--- a/docs/LocalDevelopmentSetup.md
+++ b/docs/LocalDevelopmentSetup.md
@@ -253,10 +253,10 @@ az role assignment create \
   --scope /subscriptions/<subscription-id>/resourceGroups/<resource-group-name>/providers/Microsoft.CognitiveServices/accounts/<azure-openai-name>
 ```
 ```bash
-# Assign Azure AI User role
+# Assign Foundry User role
 az role assignment create \
   --assignee <aad-user-upn> \
-  --role "Azure AI User" \
+  --role "Foundry User" \
   --scope /subscriptions/<subscription-id>/resourceGroups/<resource-group-name>/providers/Microsoft.CognitiveServices/accounts/<azure-openai-name>
 ```
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -766,7 +766,7 @@ module aiServices 'modules/ai-foundry/aifoundry.bicep' = {
       {
         principalId: appIdentity.outputs.principalId
         principalType: 'ServicePrincipal'
-        roleDefinitionIdOrName: '53ca6127-db72-4b80-b1b0-d745d6d5456d' // Azure AI User
+        roleDefinitionIdOrName: '53ca6127-db72-4b80-b1b0-d745d6d5456d' // Foundry User
       }
     ]
     tags: allTags

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,11 +5,11 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.42.1.51946",
-      "templateHash": "1333265003476738511"
+      "version": "0.43.8.12551",
+      "templateHash": "2263929965524886405"
     },
     "name": "Modernize Your Code Solution Accelerator",
-    "description": "CSA CTO Gold Standard Solution Accelerator for Modernize Your Code. \r\n"
+    "description": "CSA CTO Gold Standard Solution Accelerator for Modernize Your Code. \n"
   },
   "parameters": {
     "solutionName": {
@@ -5093,8 +5093,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.42.1.51946",
-              "templateHash": "15922750226218572834"
+              "version": "0.43.8.12551",
+              "templateHash": "14487392921976794826"
             }
           },
           "definitions": {
@@ -13102,10 +13102,10 @@
       "dependsOn": [
         "applicationInsights",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').ods)]",
-        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').agentSvc)]",
-        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').oms)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').monitor)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').storageBlob)]",
+        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').oms)]",
+        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').agentSvc)]",
         "dataCollectionEndpoint",
         "logAnalyticsWorkspace",
         "virtualNetwork"
@@ -26168,8 +26168,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.42.1.51946",
-              "templateHash": "7788164101952925462"
+              "version": "0.43.8.12551",
+              "templateHash": "5833130864503278162"
             },
             "name": "AI Services and Project Module",
             "description": "This module creates an AI Services resource and an AI Foundry project within it. It supports private networking, OpenAI deployments, and role assignments."
@@ -27466,8 +27466,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.42.1.51946",
-                      "templateHash": "3451497265231138743"
+                      "version": "0.43.8.12551",
+                      "templateHash": "427786211377533956"
                     }
                   },
                   "definitions": {
@@ -29176,8 +29176,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.42.1.51946",
-                              "templateHash": "6439859910553532577"
+                              "version": "0.43.8.12551",
+                              "templateHash": "9014582203949799641"
                             }
                           },
                           "definitions": {
@@ -29391,8 +29391,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.42.1.51946",
-                      "templateHash": "3451497265231138743"
+                      "version": "0.43.8.12551",
+                      "templateHash": "427786211377533956"
                     }
                   },
                   "definitions": {
@@ -31101,8 +31101,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.42.1.51946",
-                              "templateHash": "6439859910553532577"
+                              "version": "0.43.8.12551",
+                              "templateHash": "9014582203949799641"
                             }
                           },
                           "definitions": {
@@ -32075,8 +32075,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.42.1.51946",
-              "templateHash": "3598447245043879538"
+              "version": "0.43.8.12551",
+              "templateHash": "12228537903958998388"
             }
           },
           "definitions": {
@@ -40484,8 +40484,8 @@
       },
       "dependsOn": [
         "appIdentity",
-        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').storageFile)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').storageBlob)]",
+        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').storageFile)]",
         "logAnalyticsWorkspace",
         "virtualNetwork"
       ]
@@ -40529,8 +40529,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.42.1.51946",
-              "templateHash": "9745767047675020484"
+              "version": "0.43.8.12551",
+              "templateHash": "9897457440526781857"
             }
           },
           "definitions": {

--- a/infra/main_custom.bicep
+++ b/infra/main_custom.bicep
@@ -686,7 +686,7 @@ module aiServices 'modules/ai-foundry/aifoundry.bicep' = {
       {
         principalId: appIdentity.outputs.principalId
         principalType: 'ServicePrincipal'
-        roleDefinitionIdOrName: '53ca6127-db72-4b80-b1b0-d745d6d5456d' // Azure AI User
+        roleDefinitionIdOrName: '53ca6127-db72-4b80-b1b0-d745d6d5456d' // Foundry User
       }
     ]
     tags: allTags


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* This pull request updates role assignments and related documentation to use the "Foundry User" role instead of "Azure AI User" for AI service resources. Additionally, it includes several changes to the generated `infra/main.json` template, primarily reflecting updates from a newer Bicep compiler version and minor dependency ordering adjustments.

**Role assignment and documentation updates:**

* Updated comments and documentation in `infra/main.bicep`, `infra/main_custom.bicep`, and `docs/LocalDevelopmentSetup.md` to reference "Foundry User" instead of "Azure AI User" for role assignments. [[1]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L769-R769) [[2]](diffhunk://#diff-6f5772bf1f1d80cc16f30c80915d9e5622ad0637daf5b5dff29308ad5fc68b62L689-R689) [[3]](diffhunk://#diff-55a5226de8be9fd740c4331c2d3ad776ee0a8958b27594f1d6673d38c12c32a4L256-R259)

**Infrastructure template and dependency updates:**

* Regenerated `infra/main.json` with Bicep version `0.43.8.12551` (was `0.42.1.51946`), resulting in new `templateHash` values and minor metadata/description formatting changes. [[1]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L8-R12) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L5096-R5097) [[3]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L26171-R26172) [[4]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L27469-R27470) [[5]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L29179-R29180) [[6]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L29394-R29395) [[7]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L31104-R31105) [[8]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L32078-R32079) [[9]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L40532-R40533)
* Adjusted the order of dependencies in resource definitions within `infra/main.json` to group related DNS zones together more logically. [[1]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L13105-R13108) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L40487-R40488)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [ ] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [ ] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->

