### PR TITLE
fix: fix upload bug

### DIFF
--- a/src/backend/common/telemetry/patch_instrumentor.py
+++ b/src/backend/common/telemetry/patch_instrumentor.py
@@ -30,6 +30,54 @@ def _fixed_response_to_str(response_format: Any) -> Optional[str]:
         return str(response_format)
 
 
+def _patch_fastapi_route_details():
+    """
+    Patch opentelemetry-instrumentation-fastapi's _get_route_details.
+
+    The bug: _get_route_details() iterates over app.routes and reads
+    `starlette_route.path`. With FastAPI >= 0.119.0, app.include_router()
+    leaves an `_IncludedRouter` object in app.routes that has no `.path`
+    attribute. This raises:
+        AttributeError: '_IncludedRouter' object has no attribute 'path'
+
+    It is triggered on requests where no concrete route matches FULL,
+    most notably CORS preflight `OPTIONS` requests from the frontend,
+    causing a 500 on the preflight and blocking the real request.
+
+    The fix: replace the module-level _get_route_details with a version
+    that uses getattr(..., "path", None) and ignores routes whose
+    matches() raises. _get_default_span_details references this function
+    as a module global, so patching the module attribute is sufficient.
+    """
+    try:
+        import opentelemetry.instrumentation.fastapi as fastapi_instr
+        from starlette.routing import Match
+    except ImportError:
+        logger.debug("opentelemetry.instrumentation.fastapi not installed, skipping patch")
+        return
+
+    try:
+        def _safe_get_route_details(scope: Any) -> Optional[str]:
+            app = scope["app"]
+            route = None
+            for starlette_route in app.routes:
+                try:
+                    match, _ = starlette_route.matches(scope)
+                except Exception:  # noqa: BLE001
+                    continue
+                if match == Match.FULL:
+                    route = getattr(starlette_route, "path", None)
+                    break
+                if match == Match.PARTIAL:
+                    route = getattr(starlette_route, "path", None)
+            return route
+
+        fastapi_instr._get_route_details = _safe_get_route_details
+        logger.info("Patched opentelemetry.instrumentation.fastapi._get_route_details")
+    except Exception:  # noqa: BLE001
+        logger.exception("Failed to patch opentelemetry.instrumentation.fastapi route details")
+
+
 def patch_instrumentors():
     """
     Patch Azure AI telemetry instrumentors to handle dict response_format.
@@ -60,3 +108,8 @@ def patch_instrumentors():
         logger.info("Patched azure.ai.projects instrumentor")
     except ImportError:
         logger.debug("azure.ai.projects telemetry not installed, skipping patch")
+
+    # Patch opentelemetry-instrumentation-fastapi to tolerate routes without a
+    # `.path` attribute (e.g. FastAPI >= 0.119.0 `_IncludedRouter`), which
+    # otherwise crashes span-name resolution on CORS preflight OPTIONS requests.
+    _patch_fastapi_route_details()

--- a/src/tests/backend/app_test.py
+++ b/src/tests/backend/app_test.py
@@ -30,7 +30,13 @@ async def test_health_check(app: FastAPI):
 @pytest.mark.asyncio
 async def test_backend_routes_exist(app: FastAPI):
     """Ensure /api routes are available (smoke test)."""
-    # Check available routes include /api prefix from backend_router
-    routes = [route.path for route in app.router.routes]
-    backend_routes = [r for r in routes if r.startswith("/api")]
+    # Check available routes include /api prefix from backend_router.
+    # Newer FastAPI/Starlette versions wrap included routers in objects
+    # (e.g. _IncludedRouter / Mount) that expose `prefix` instead of `path`,
+    # so fall back to either attribute when collecting route identifiers.
+    routes = [
+        getattr(route, "path", None) or getattr(route, "prefix", "")
+        for route in app.router.routes
+    ]
+    backend_routes = [r for r in routes if r and r.startswith("/api")]
     assert backend_routes, "No backend routes found under /api prefix"

--- a/src/tests/backend/app_test.py
+++ b/src/tests/backend/app_test.py
@@ -30,13 +30,12 @@ async def test_health_check(app: FastAPI):
 @pytest.mark.asyncio
 async def test_backend_routes_exist(app: FastAPI):
     """Ensure /api routes are available (smoke test)."""
-    # Check available routes include /api prefix from backend_router.
-    # Newer FastAPI/Starlette versions wrap included routers in objects
-    # (e.g. _IncludedRouter / Mount) that expose `prefix` instead of `path`,
-    # so fall back to either attribute when collecting route identifiers.
-    routes = [
-        getattr(route, "path", None) or getattr(route, "prefix", "")
-        for route in app.router.routes
-    ]
-    backend_routes = [r for r in routes if r and r.startswith("/api")]
-    assert backend_routes, "No backend routes found under /api prefix"
+    # Use the OpenAPI schema rather than walking `app.router.routes`, because
+    # newer FastAPI versions wrap included routers in an `_IncludedRouter`
+    # object (no `.path` attribute) which makes direct route iteration fragile.
+    # The OpenAPI `paths` mapping is the stable public surface and always
+    # contains the fully-resolved paths including the `/api` prefix added by
+    # `app.include_router(backend_router, prefix="/api", ...)`.
+    paths = app.openapi().get("paths", {})
+    backend_paths = [p for p in paths if p.startswith("/api")]
+    assert backend_paths, "No backend routes found under /api prefix"


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->

This pull request introduces a patch to improve compatibility with FastAPI >= 0.119.0 when using the OpenTelemetry FastAPI instrumentation. The main change is the addition of a workaround to prevent crashes during span-name resolution for CORS preflight `OPTIONS` requests, which previously caused 500 errors due to an AttributeError. The patch ensures that the telemetry instrumentation can safely handle routes that do not have a `.path` attribute.

Key changes:

**Bug Fixes and Compatibility:**

* Added a `_patch_fastapi_route_details` function in `patch_instrumentor.py` to patch `opentelemetry.instrumentation.fastapi._get_route_details`, making it robust against routes without a `.path` attribute (such as `_IncludedRouter` in FastAPI >= 0.119.0), thereby preventing 500 errors on CORS preflight requests.

* Updated `patch_instrumentors()` to invoke the new patch, ensuring the fix is applied during telemetry instrumentor setup.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->

