### PR TITLE
chore: down merging the changes from main

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # Each line is a file pattern followed by one or more owners.
 
 # These owners will be the default owners for everything in the repo.
-* @Avijit-Microsoft @Roopan-Microsoft @Prajwal-Microsoft @aniaroramsft @marktayl1 @Vinay-Microsoft @toherman-msft @nchandhi @dgp10801
+* @Avijit-Microsoft @Roopan-Microsoft @Prajwal1-Microsoft @aniaroramsft @marktayl1 @VinaySh-Microsoft @toherman-msft @nchandhi @dgp10801

--- a/azure.yaml
+++ b/azure.yaml
@@ -1,6 +1,6 @@
 name: modernize-your-code-solution-accelerator
-metadata:
-    template: modernize-your-code-solution-accelerator@1.0
+# metadata:
+#     template: modernize-your-code-solution-accelerator@1.0
 
 requiredVersions:
   azd: '>= 1.18.0 != 1.23.9'
@@ -22,3 +22,18 @@ deployment:
     AzureAiServiceLocation: ${{ parameters.AzureAiServiceLocation }}
     Prefix: ${{ parameters.Prefix }}
     baseUrl: ${{ parameters.baseUrl }}
+
+# After provisioning, build the backend/frontend images remotely in the newly
+# provisioned Azure Container Registry and update the container apps to use them.
+hooks:
+  postprovision:
+    windows:
+      shell: pwsh
+      run: ./scripts/build_and_push_images.ps1
+      continueOnError: false
+      interactive: true
+    posix:
+      shell: sh
+      run: ./scripts/build_and_push_images.sh
+      continueOnError: false
+      interactive: true

--- a/azure.yaml
+++ b/azure.yaml
@@ -1,6 +1,6 @@
 name: modernize-your-code-solution-accelerator
-# metadata:
-#     template: modernize-your-code-solution-accelerator@1.0
+metadata:
+    template: modernize-your-code-solution-accelerator@1.0
 
 requiredVersions:
   azd: '>= 1.18.0 != 1.23.9'
@@ -22,18 +22,3 @@ deployment:
     AzureAiServiceLocation: ${{ parameters.AzureAiServiceLocation }}
     Prefix: ${{ parameters.Prefix }}
     baseUrl: ${{ parameters.baseUrl }}
-
-# After provisioning, build the backend/frontend images remotely in the newly
-# provisioned Azure Container Registry and update the container apps to use them.
-hooks:
-  postprovision:
-    windows:
-      shell: pwsh
-      run: ./scripts/build_and_push_images.ps1
-      continueOnError: false
-      interactive: true
-    posix:
-      shell: sh
-      run: ./scripts/build_and_push_images.sh
-      continueOnError: false
-      interactive: true

--- a/docs/CustomizingAzdParameters.md
+++ b/docs/CustomizingAzdParameters.md
@@ -16,13 +16,12 @@ By default this template will use the environment name as the prefix to prevent 
 | `AZURE_ENV_GPT_MODEL_VERSION`          | string  | `2024-08-06`     | Set the Azure model version (allowed values: 2024-08-06)    |
 | `AZURE_ENV_GPT_MODEL_CAPACITY`         | integer | `150`            | Set the Model Capacity (choose a number based on available GPT model capacity in your subscription). |
 | `AZURE_ENV_EXISTING_LOG_ANALYTICS_WORKSPACE_RID`| string  | Guide to get your [Existing Workspace ID](/docs/re-use-log-analytics.md)     | Set this if you want to reuse an existing Log Analytics Workspace instead of creating a new one.     |
-| `AZURE_ENV_IMAGE_TAG`                  | string  | `latest`         | Set the Image tag Like (allowed values: latest, dev, hotfix)    |
+| `AZURE_ENV_IMAGE_TAG`                  | string  | `latest`         | Tag applied to the backend/frontend images that are built remotely and pushed to the deployment's Azure Container Registry.    |
 | `AZURE_ENV_VM_SIZE`                    | string  | `Standard_D2s_v5`         | Specifies the size of the Jumpbox Virtual Machine (e.g., `Standard_D2s_v5`, `Standard_D2s_v4`). Set a custom value if `enablePrivateNetworking` is `true`.    |
 | `AZURE_ENV_JUMPBOX_ADMIN_USERNAME`     | string  | `JumpboxAdminUser`          | Specifies the administrator username for the Jumpbox Virtual Machine.      |
 | `AZURE_ENV_JUMPBOX_ADMIN_PASSWORD`     | string  | `JumpboxAdminP@ssw0rd1234!` | Specifies the administrator password for the Jumpbox Virtual Machine.      |
 | `AZURE_ENV_COSMOS_SECONDARY_LOCATION`  | string  | *(not set by default)*      | Specifies the secondary region for Cosmos DB. Required if `enableRedundancy` is `true`. |
 | `AZURE_EXISTING_AIPROJECT_RESOURCE_ID` | string  | *(not set by default)*      | Specifies the existing AI Foundry Project Resource ID if it needs to be reused. |
-| `AZURE_ENV_CONTAINER_REGISTRY_ENDPOINT`| string  | *(not set by default)*      | Specifies the Azure Container Registry endpoint to use for container images. |
 
 ---
 

--- a/docs/CustomizingAzdParameters.md
+++ b/docs/CustomizingAzdParameters.md
@@ -12,10 +12,10 @@ By default this template will use the environment name as the prefix to prevent 
 | `AZURE_LOCATION`                       | string  | `<User selects during deployment>`      | Location of the Azure resources. Controls where the infrastructure will be deployed.                 |
 | `AZURE_ENV_AI_SERVICE_LOCATION`        | string  | `<User selects during deployment>`     | Location of the Azure resources. Controls where the Azure AI Services will be deployed. |
 | `AZURE_ENV_MODEL_DEPLOYMENT_TYPE`      | string  | `GlobalStandard` | Change the Model Deployment Type (allowed values: Standard, GlobalStandard).                         |
-| `AZURE_ENV_GPT_MODEL_NAME`             | string  | `gpt-4o`         | Set the Model Name (allowed values: gpt-4o).                                                         |
-| `AZURE_ENV_GPT_MODEL_VERSION`          | string  | `2024-08-06`     | Set the Azure model version (allowed values: 2024-08-06)    |
+| `AZURE_ENV_GPT_MODEL_NAME`             | string  | `gpt-5.1`         | Set the Model Name (allowed values: gpt-5.1).                                                         |
+| `AZURE_ENV_GPT_MODEL_VERSION`          | string  | `2025-11-13`     | Set the Azure model version (allowed values: 2025-11-13)    |
 | `AZURE_ENV_GPT_MODEL_CAPACITY`         | integer | `150`            | Set the Model Capacity (choose a number based on available GPT model capacity in your subscription). |
-| `AZURE_ENV_EXISTING_LOG_ANALYTICS_WORKSPACE_RID`| string  | Guide to get your [Existing Workspace ID](/docs/re-use-log-analytics.md)     | Set this if you want to reuse an existing Log Analytics Workspace instead of creating a new one.     |
+| `AZURE_ENV_EXISTING_LOG_ANALYTICS_WORKSPACE_RID`| string  | Guide to get your [Existing Workspace ID](re-use-log-analytics.md)     | Set this if you want to reuse an existing Log Analytics Workspace instead of creating a new one.     |
 | `AZURE_ENV_IMAGE_TAG`                  | string  | `latest`         | Tag applied to the backend/frontend images that are built remotely and pushed to the deployment's Azure Container Registry.    |
 | `AZURE_ENV_VM_SIZE`                    | string  | `Standard_D2s_v5`         | Specifies the size of the Jumpbox Virtual Machine (e.g., `Standard_D2s_v5`, `Standard_D2s_v4`). Set a custom value if `enablePrivateNetworking` is `true`.    |
 | `AZURE_ENV_JUMPBOX_ADMIN_USERNAME`     | string  | `JumpboxAdminUser`          | Specifies the administrator username for the Jumpbox Virtual Machine.      |

--- a/docs/DeploymentGuide.md
+++ b/docs/DeploymentGuide.md
@@ -286,7 +286,11 @@ azd up
 3. **Azure region** - Select a region with available GPT model quota
 4. **Resource group** selection (create new or use existing)
 
-**Expected Duration:** 6-9 minutes for default configuration
+**Expected Duration:** 9-14 minutes for default configuration (includes remotely building and pushing the container images)
+
+> **ℹ️ How the application images are built:** Every deployment provisions its own **Azure Container Registry (ACR)**. The container apps are first created with a public "hello world" placeholder image, then a `postprovision` hook runs [`scripts/build_and_push_images.sh`](../scripts/build_and_push_images.sh) (or [`scripts/build_and_push_images.ps1`](../scripts/build_and_push_images.ps1) on Windows). This script builds the backend and frontend images **remotely** in your ACR using `az acr build` (no local Docker required), pushes them, and updates the container apps to run the freshly built images.
+>
+> **Azure CLI sign-in required:** The post-provision hook uses the Azure CLI. In addition to `azd auth login`, make sure you are signed in with `az login` (and `az account set --subscription <id>` if you have multiple subscriptions) before running `azd up`. In GitHub Codespaces and Dev Containers the Azure CLI is preinstalled.
 
 **⚠️ Deployment Issues:** If you encounter errors or timeouts, try a different region as there may be capacity constraints. For detailed error solutions, see our [Troubleshooting Guide](./TroubleShootingSteps.md).
 

--- a/docs/DeploymentGuide.md
+++ b/docs/DeploymentGuide.md
@@ -280,6 +280,22 @@ azd config set provision.preflight off
 azd up
 ```
 
+## Step 5: Post-Deployment Configuration
+### 5.1 Run Post Deployment Script
+ 
+1. You can run the ACR build and push script from the project root. Use the appropriate command for your shell:
+ 
+   - For Bash (Linux/macOS/WSL):
+ 
+     ```bash
+     bash infra/scripts/build_and_push_images.sh
+     ```
+ 
+   - For PowerShell (Windows):
+ 
+     ```powershell
+     infra\scripts\build_and_push_images.ps1
+
 **During deployment, you'll be prompted for:**
 1. **Environment name** (e.g., "cmsaapp") - Must be 3-16 characters long, alphanumeric only
 2. **Azure subscription** selection
@@ -288,13 +304,9 @@ azd up
 
 **Expected Duration:** 9-14 minutes for default configuration (includes remotely building and pushing the container images)
 
-> **ℹ️ How the application images are built:** Every deployment provisions its own **Azure Container Registry (ACR)**. The container apps are first created with a public "hello world" placeholder image, then a `postprovision` hook runs [`scripts/build_and_push_images.sh`](../scripts/build_and_push_images.sh) (or [`scripts/build_and_push_images.ps1`](../scripts/build_and_push_images.ps1) on Windows). This script builds the backend and frontend images **remotely** in your ACR using `az acr build` (no local Docker required), pushes them, and updates the container apps to run the freshly built images.
->
-> **Azure CLI sign-in required:** The post-provision hook uses the Azure CLI. In addition to `azd auth login`, make sure you are signed in with `az login` (and `az account set --subscription <id>` if you have multiple subscriptions) before running `azd up`. In GitHub Codespaces and Dev Containers the Azure CLI is preinstalled.
-
 **⚠️ Deployment Issues:** If you encounter errors or timeouts, try a different region as there may be capacity constraints. For detailed error solutions, see our [Troubleshooting Guide](./TroubleShootingSteps.md).
 
-### 4.3 Get Application URL
+### 5.2 Get Application URL
 
 After successful deployment:
 1. Open [Azure Portal](https://portal.azure.com/)
@@ -302,24 +314,24 @@ After successful deployment:
 3. Find the Container App with "frontend" in the name
 4. Copy the **Application URI**
 
-⚠️ **Important:** Complete [Post-Deployment Steps](#step-5-post-deployment-configuration) before accessing the application.
+⚠️ **Important:** Complete [Post-Deployment Steps](#step-6-post-deployment-configuration) before accessing the application.
 
-## Step 5: Post-Deployment Configuration
+## Step 6: Post-Deployment Configuration
 
-### 5.1 Configure Authentication (Required)
+### 6.1 Configure Authentication (Required)
 
 **This step is mandatory for application access:**
 
 1. Follow [App Authentication Configuration](./AddAuthentication.md)
 2. Wait up to 10 minutes for authentication changes to take effect
 
-### 5.2 Verify Deployment
+### 6.2 Verify Deployment
 
-1. Access your application using the URL from Step 4.3
+1. Access your application using the URL from Step 5.2
 2. Confirm the application loads successfully
 3. Verify you can sign in with your authenticated account
 
-### 5.3 Test the Application
+### 6.3 Test the Application
 
 Follow the detailed workflow to test the migration functionality:
 
@@ -333,7 +345,7 @@ Follow the detailed workflow to test the migration functionality:
 
 📖 **Detailed Instructions:** See the complete [Sample Workflow](./SampleWorkflow.md) guide for step-by-step testing procedures.
 
-## Step 6: Clean Up (Optional)
+## Step 7: Clean Up (Optional)
 
 ### Remove All Resources
 ```shell

--- a/docs/DeploymentGuide.md
+++ b/docs/DeploymentGuide.md
@@ -280,21 +280,22 @@ azd config set provision.preflight off
 azd up
 ```
 
-## Step 5: Post-Deployment Configuration
-### 5.1 Run Post Deployment Script
+## Step 5: Build and Push Container Images
+### 5.1 Run Image Build Script
  
 1. You can run the ACR build and push script from the project root. Use the appropriate command for your shell:
  
    - For Bash (Linux/macOS/WSL):
  
      ```bash
-     bash infra/scripts/build_and_push_images.sh
+     bash scripts/build_and_push_images.sh
      ```
  
    - For PowerShell (Windows):
  
-     ```powershell
-     infra\scripts\build_and_push_images.ps1
+     ```
+     .\scripts\build_and_push_images.ps1
+     ```
 
 **During deployment, you'll be prompted for:**
 1. **Environment name** (e.g., "cmsaapp") - Must be 3-16 characters long, alphanumeric only
@@ -314,7 +315,7 @@ After successful deployment:
 3. Find the Container App with "frontend" in the name
 4. Copy the **Application URI**
 
-⚠️ **Important:** Complete [Post-Deployment Steps](#step-6-post-deployment-configuration) before accessing the application.
+⚠️ **Important:** Complete Step 5.1 and Step 6.1 before accessing the application.
 
 ## Step 6: Post-Deployment Configuration
 

--- a/docs/DeploymentGuide.md
+++ b/docs/DeploymentGuide.md
@@ -279,6 +279,15 @@ azd config set provision.preflight off
 ```shell
 azd up
 ```
+**During deployment, you'll be prompted for:**
+1. **Environment name** (e.g., "cmsaapp") - Must be 3-16 characters long, alphanumeric only
+2. **Azure subscription** selection
+3. **Azure region** - Select a region with available GPT model quota
+4. **Resource group** selection (create new or use existing)
+
+**Expected Duration:** 9-14 minutes for default configuration (includes remotely building and pushing the container images)
+
+**⚠️ Deployment Issues:** If you encounter errors or timeouts, try a different region as there may be capacity constraints. For detailed error solutions, see our [Troubleshooting Guide](./TroubleShootingSteps.md).
 
 ## Step 5: Build and Push Container Images
 ### 5.1 Run Image Build Script
@@ -296,16 +305,6 @@ azd up
      ```
      .\scripts\build_and_push_images.ps1
      ```
-
-**During deployment, you'll be prompted for:**
-1. **Environment name** (e.g., "cmsaapp") - Must be 3-16 characters long, alphanumeric only
-2. **Azure subscription** selection
-3. **Azure region** - Select a region with available GPT model quota
-4. **Resource group** selection (create new or use existing)
-
-**Expected Duration:** 9-14 minutes for default configuration (includes remotely building and pushing the container images)
-
-**⚠️ Deployment Issues:** If you encounter errors or timeouts, try a different region as there may be capacity constraints. For detailed error solutions, see our [Troubleshooting Guide](./TroubleShootingSteps.md).
 
 ### 5.2 Get Application URL
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -34,7 +34,7 @@ param location string = resourceGroup().location
   azd : {
     type: 'location'
     usageName : [
-      'OpenAI.GlobalStandard.gpt-4o, 150'
+      'OpenAI.GlobalStandard.gpt-5.1, 150'
     ]
   }
 })

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -98,19 +98,16 @@ param enableTelemetry bool = true
 param deploymentType string = 'GlobalStandard'
 
 @minLength(1)
-@description('Optional. Name of the GPT model to deploy. Defaults to gpt-4o.')
-param gptModelName string = 'gpt-4o'
+@description('Optional. Name of the GPT model to deploy. Defaults to gpt-5.1.')
+param gptModelName string = 'gpt-5.1'
 
 @minLength(1)
-@description('Optional. Set the Image tag. Defaults to latest_2025-11-10_599.')
-param imageTag string = 'latest_2025-11-10_599'
-
-@description('Optional. Azure Container Registry endpoint. Defaults to cmsacontainerreg.azurecr.io')
-param containerRegistryEndpoint string = 'cmsacontainerreg.azurecr.io'
+@description('Optional. Image tag applied to the backend/frontend images that are built remotely and pushed to the deployment\'s Azure Container Registry by the post-provision script. Defaults to latest.')
+param imageTag string = 'latest'
 
 @minLength(1)
-@description('Optional. Version of the GPT model to deploy. Defaults to 2024-08-06.')
-param gptModelVersion string = '2024-08-06'
+@description('Optional. Version of the GPT model to deploy. Defaults to 2025-11-13.')
+param gptModelVersion string = '2025-11-13'
 
 @description('Optional. Use this parameter to use an existing AI project resource ID. Defaults to empty string.')
 param existingFoundryProjectResourceId string = ''
@@ -897,6 +894,35 @@ module cosmosDb 'modules/cosmosDb.bicep' = {
   }
 }
 
+// ========== Azure Container Registry ========== //
+// A dedicated Azure Container Registry is provisioned with every deployment.
+// The container apps are initially created with a public "hello world" placeholder
+// image; the post-provision script (scripts/build_and_push_images.*) builds the
+// backend/frontend images remotely with 'az acr build', pushes them to this registry,
+// and then updates the container apps to run the freshly built images.
+var placeholderContainerImage = 'mcr.microsoft.com/azuredocs/containerapps-helloworld:latest'
+
+module containerRegistry 'br/public:avm/res/container-registry/registry:0.12.1' = {
+  name: take('avm.res.container-registry.registry.${solutionSuffix}', 64)
+  params: {
+    #disable-next-line BCP334 // solutionSuffix always yields a name of sufficient length at deployment time
+    name: take('cr${solutionSuffix}', 50)
+    location: location
+    acrSku: enableRedundancy ? 'Premium' : 'Standard'
+    acrAdminUserEnabled: false
+    zoneRedundancy: enableRedundancy ? 'Enabled' : 'Disabled'
+    roleAssignments: [
+      {
+        principalId: appIdentity.outputs.principalId
+        principalType: 'ServicePrincipal'
+        roleDefinitionIdOrName: 'AcrPull'
+      }
+    ]
+    tags: allTags
+    enableTelemetry: enableTelemetry
+  }
+}
+
 var containerAppsEnvironmentName = 'cae-${solutionSuffix}'
 
 module containerAppsEnvironment 'br/public:avm/res/app/managed-environment:0.13.1' = {
@@ -953,10 +979,17 @@ module containerAppBackend 'br/public:avm/res/app/container-app:0.22.0' = {
         appIdentity.outputs.resourceId
       ]
     }
+    registries: [
+      {
+        server: containerRegistry.outputs.loginServer
+        identity: appIdentity.outputs.resourceId
+      }
+    ]
     containers: [
       {
         name: 'cmsabackend'
-        image: '${containerRegistryEndpoint}/cmsabackend:${imageTag}'
+        // Placeholder image; replaced with the ACR image by scripts/build_and_push_images.*
+        image: placeholderContainerImage
         env: concat(
           [
             {
@@ -1133,6 +1166,12 @@ module containerAppFrontend 'br/public:avm/res/app/container-app:0.22.0' = {
         appIdentity.outputs.resourceId
       ]
     }
+    registries: [
+      {
+        server: containerRegistry.outputs.loginServer
+        identity: appIdentity.outputs.resourceId
+      }
+    ]
     containers: [
       {
         env: [
@@ -1145,7 +1184,8 @@ module containerAppFrontend 'br/public:avm/res/app/container-app:0.22.0' = {
             value: 'prod'
           }
         ]
-        image: '${containerRegistryEndpoint}/cmsafrontend:${imageTag}'
+        // Placeholder image; replaced with the ACR image by scripts/build_and_push_images.*
+        image: placeholderContainerImage
         name: 'cmsafrontend'
         resources: {
           cpu: 1
@@ -1202,3 +1242,18 @@ output PICKER_AGENT_MODEL_DEPLOY string = modelDeployment.name
 output FIXER_AGENT_MODEL_DEPLOY string = modelDeployment.name
 output SEMANTIC_VERIFIER_AGENT_MODEL_DEPLOY string = modelDeployment.name
 output SYNTAX_CHECKER_AGENT_MODEL_DEPLOY string = modelDeployment.name  
+
+// ========== Container Registry / image build outputs ========== //
+// Consumed by the post-provision script (scripts/build_and_push_images.*) to build
+// and push the application images and update the container apps.
+@description('Login server of the Azure Container Registry provisioned for this deployment.')
+output AZURE_CONTAINER_REGISTRY_ENDPOINT string = containerRegistry.outputs.loginServer
+@description('Name of the Azure Container Registry provisioned for this deployment.')
+output AZURE_CONTAINER_REGISTRY_NAME string = containerRegistry.outputs.name
+@description('Image tag used when building and pushing the backend/frontend images.')
+output AZURE_ENV_IMAGE_TAG string = imageTag
+@description('Name of the backend container app to update with the freshly built image.')
+output BACKEND_CONTAINER_APP_NAME string = containerAppBackend.outputs.name
+@description('Name of the frontend container app to update with the freshly built image.')
+output FRONTEND_CONTAINER_APP_NAME string = containerAppFrontend.outputs.name
+

--- a/infra/main.json
+++ b/infra/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.44.1.10279",
-      "templateHash": "8622787143015571536"
+      "templateHash": "4200460093633058559"
     },
     "name": "Modernize Your Code Solution Accelerator",
     "description": "CSA CTO Gold Standard Solution Accelerator for Modernize Your Code. \r\n"
@@ -58,7 +58,7 @@
         "azd": {
           "type": "location",
           "usageName": [
-            "OpenAI.GlobalStandard.gpt-4o, 150"
+            "OpenAI.GlobalStandard.gpt-5.1, 150"
           ]
         },
         "description": "Required. Location for all AI service resources. This location can be different from the resource group location."
@@ -13095,11 +13095,11 @@
       },
       "dependsOn": [
         "applicationInsights",
-        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').storageBlob)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').agentSvc)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').monitor)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').ods)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').oms)]",
+        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').storageBlob)]",
         "dataCollectionEndpoint",
         "logAnalyticsWorkspace",
         "virtualNetwork"

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.42.1.51946",
-      "templateHash": "18156607440911418905"
+      "version": "0.44.1.10279",
+      "templateHash": "8622787143015571536"
     },
     "name": "Modernize Your Code Solution Accelerator",
     "description": "CSA CTO Gold Standard Solution Accelerator for Modernize Your Code. \r\n"
@@ -151,33 +151,26 @@
     },
     "gptModelName": {
       "type": "string",
-      "defaultValue": "gpt-4o",
+      "defaultValue": "gpt-5.1",
       "minLength": 1,
       "metadata": {
-        "description": "Optional. Name of the GPT model to deploy. Defaults to gpt-4o."
+        "description": "Optional. Name of the GPT model to deploy. Defaults to gpt-5.1."
       }
     },
     "imageTag": {
       "type": "string",
-      "defaultValue": "latest_2025-11-10_599",
+      "defaultValue": "latest",
       "minLength": 1,
       "metadata": {
-        "description": "Optional. Set the Image tag. Defaults to latest_2025-11-10_599."
-      }
-    },
-    "containerRegistryEndpoint": {
-      "type": "string",
-      "defaultValue": "cmsacontainerreg.azurecr.io",
-      "metadata": {
-        "description": "Optional. Azure Container Registry endpoint. Defaults to cmsacontainerreg.azurecr.io"
+        "description": "Optional. Image tag applied to the backend/frontend images that are built remotely and pushed to the deployment's Azure Container Registry by the post-provision script. Defaults to latest."
       }
     },
     "gptModelVersion": {
       "type": "string",
-      "defaultValue": "2024-08-06",
+      "defaultValue": "2025-11-13",
       "minLength": 1,
       "metadata": {
-        "description": "Optional. Version of the GPT model to deploy. Defaults to 2024-08-06."
+        "description": "Optional. Version of the GPT model to deploy. Defaults to 2025-11-13."
       }
     },
     "existingFoundryProjectResourceId": {
@@ -268,6 +261,7 @@
     "aiFoundryAiServicesResourceName": "[format('aif-{0}', variables('solutionSuffix'))]",
     "useExistingAiFoundryAiProject": "[not(empty(parameters('existingFoundryProjectResourceId')))]",
     "appStorageContainerName": "appstorage",
+    "placeholderContainerImage": "mcr.microsoft.com/azuredocs/containerapps-helloworld:latest",
     "containerAppsEnvironmentName": "[format('cae-{0}', variables('solutionSuffix'))]"
   },
   "resources": {
@@ -5093,8 +5087,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.42.1.51946",
-              "templateHash": "15922750226218572834"
+              "version": "0.44.1.10279",
+              "templateHash": "12666388833640590711"
             }
           },
           "definitions": {
@@ -13101,11 +13095,11 @@
       },
       "dependsOn": [
         "applicationInsights",
-        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').oms)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').storageBlob)]",
-        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').ods)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').agentSvc)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').monitor)]",
+        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').ods)]",
+        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').oms)]",
         "dataCollectionEndpoint",
         "logAnalyticsWorkspace",
         "virtualNetwork"
@@ -26189,8 +26183,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.42.1.51946",
-              "templateHash": "7788164101952925462"
+              "version": "0.44.1.10279",
+              "templateHash": "7796390788683636674"
             },
             "name": "AI Services and Project Module",
             "description": "This module creates an AI Services resource and an AI Foundry project within it. It supports private networking, OpenAI deployments, and role assignments."
@@ -27487,8 +27481,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.42.1.51946",
-                      "templateHash": "3451497265231138743"
+                      "version": "0.44.1.10279",
+                      "templateHash": "15798298565583456780"
                     }
                   },
                   "definitions": {
@@ -29197,8 +29191,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.42.1.51946",
-                              "templateHash": "6439859910553532577"
+                              "version": "0.44.1.10279",
+                              "templateHash": "13008301984486295222"
                             }
                           },
                           "definitions": {
@@ -29412,8 +29406,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.42.1.51946",
-                      "templateHash": "3451497265231138743"
+                      "version": "0.44.1.10279",
+                      "templateHash": "15798298565583456780"
                     }
                   },
                   "definitions": {
@@ -31122,8 +31116,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.42.1.51946",
-                              "templateHash": "6439859910553532577"
+                              "version": "0.44.1.10279",
+                              "templateHash": "13008301984486295222"
                             }
                           },
                           "definitions": {
@@ -32039,8 +32033,8 @@
       "dependsOn": [
         "aiServices",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').aiServices)]",
-        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').cognitiveServices)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').openAI)]",
+        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').cognitiveServices)]",
         "virtualNetwork"
       ]
     },
@@ -32096,8 +32090,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.42.1.51946",
-              "templateHash": "15460841004653840446"
+              "version": "0.44.1.10279",
+              "templateHash": "17237339939537137976"
             }
           },
           "definitions": {
@@ -40505,8 +40499,8 @@
       },
       "dependsOn": [
         "appIdentity",
-        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').storageBlob)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').storageFile)]",
+        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').storageBlob)]",
         "logAnalyticsWorkspace",
         "virtualNetwork"
       ]
@@ -40550,8 +40544,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.42.1.51946",
-              "templateHash": "9745767047675020484"
+              "version": "0.44.1.10279",
+              "templateHash": "8524856574515803596"
             }
           },
           "definitions": {
@@ -46808,6 +46802,3853 @@
         "virtualNetwork"
       ]
     },
+    "containerRegistry": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[take(format('avm.res.container-registry.registry.{0}', variables('solutionSuffix')), 64)]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "name": {
+            "value": "[take(format('cr{0}', variables('solutionSuffix')), 50)]"
+          },
+          "location": {
+            "value": "[parameters('location')]"
+          },
+          "acrSku": "[if(parameters('enableRedundancy'), createObject('value', 'Premium'), createObject('value', 'Standard'))]",
+          "acrAdminUserEnabled": {
+            "value": false
+          },
+          "zoneRedundancy": "[if(parameters('enableRedundancy'), createObject('value', 'Enabled'), createObject('value', 'Disabled'))]",
+          "roleAssignments": {
+            "value": [
+              {
+                "principalId": "[reference('appIdentity').outputs.principalId.value]",
+                "principalType": "ServicePrincipal",
+                "roleDefinitionIdOrName": "AcrPull"
+              }
+            ]
+          },
+          "tags": {
+            "value": "[variables('allTags')]"
+          },
+          "enableTelemetry": {
+            "value": "[parameters('enableTelemetry')]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "languageVersion": "2.0",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.42.1.51946",
+              "templateHash": "1509121545318808417"
+            },
+            "name": "Azure Container Registries (ACR)",
+            "description": "This module deploys an Azure Container Registry (ACR)."
+          },
+          "definitions": {
+            "privateEndpointOutputType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "The name of the private endpoint."
+                  }
+                },
+                "resourceId": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "The resource ID of the private endpoint."
+                  }
+                },
+                "groupId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "The group Id for the private endpoint Group."
+                  }
+                },
+                "customDnsConfigs": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "fqdn": {
+                        "type": "string",
+                        "nullable": true,
+                        "metadata": {
+                          "description": "FQDN that resolves to private endpoint IP address."
+                        }
+                      },
+                      "ipAddresses": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "metadata": {
+                          "description": "A list of private IP addresses of the private endpoint."
+                        }
+                      }
+                    }
+                  },
+                  "metadata": {
+                    "description": "The custom DNS configurations of the private endpoint."
+                  }
+                },
+                "networkInterfaceResourceIds": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "metadata": {
+                    "description": "The IDs of the network interfaces associated with the private endpoint."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true
+              }
+            },
+            "credentialSetType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The name of the credential set."
+                  }
+                },
+                "managedIdentities": {
+                  "$ref": "#/definitions/managedIdentityOnlySysAssignedType",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The managed identity definition for this resource."
+                  }
+                },
+                "authCredentials": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/authCredentialsType"
+                  },
+                  "metadata": {
+                    "description": "Required. List of authentication credentials stored for an upstream. Usually consists of a primary and an optional secondary credential."
+                  }
+                },
+                "loginServer": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The credentials are stored for this upstream or login server."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true,
+                "description": "The type for a credential set."
+              }
+            },
+            "scopeMapsType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The name of the scope map."
+                  }
+                },
+                "actions": {
+                  "type": "array",
+                  "metadata": {
+                    "__bicep_resource_derived_type!": {
+                      "source": "Microsoft.ContainerRegistry/registries/scopeMaps@2025-03-01-preview#properties/properties/properties/actions"
+                    },
+                    "description": "Required. The list of scoped permissions for registry artifacts."
+                  }
+                },
+                "description": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The user friendly description of the scope map."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true,
+                "description": "The type for a scope map."
+              }
+            },
+            "cacheRuleType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The name of the cache rule. Will be derived from the source repository name if not defined."
+                  }
+                },
+                "sourceRepository": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. Source repository pulled from upstream."
+                  }
+                },
+                "targetRepository": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Target repository specified in docker pull command. E.g.: docker pull myregistry.azurecr.io/{targetRepository}:{tag}."
+                  }
+                },
+                "credentialSetResourceId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The resource ID of the credential store which is associated with the cache rule."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true,
+                "description": "The type for a cache rule."
+              }
+            },
+            "replicationType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The name of the replication."
+                  }
+                },
+                "location": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Location for all resources."
+                  }
+                },
+                "tags": {
+                  "type": "object",
+                  "metadata": {
+                    "__bicep_resource_derived_type!": {
+                      "source": "Microsoft.ContainerRegistry/registries/replications@2025-03-01-preview#properties/tags"
+                    },
+                    "description": "Optional. Tags of the resource."
+                  },
+                  "nullable": true
+                },
+                "regionEndpointEnabled": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Specifies whether the replication regional endpoint is enabled. Requests will not be routed to a replication whose regional endpoint is disabled, however its data will continue to be synced with other replications."
+                  }
+                },
+                "zoneRedundancy": {
+                  "type": "string",
+                  "metadata": {
+                    "__bicep_resource_derived_type!": {
+                      "source": "Microsoft.ContainerRegistry/registries@2025-03-01-preview#properties/properties/properties/zoneRedundancy"
+                    },
+                    "description": "Optional. Whether or not zone redundancy is enabled for this container registry."
+                  },
+                  "nullable": true
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true,
+                "description": "The type for a replication."
+              }
+            },
+            "taskType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The name of the task."
+                  }
+                },
+                "location": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Location for all resources."
+                  }
+                },
+                "tags": {
+                  "type": "object",
+                  "metadata": {
+                    "__bicep_resource_derived_type!": {
+                      "source": "Microsoft.ContainerRegistry/registries/tasks@2025-03-01-preview#properties/tags"
+                    },
+                    "description": "Optional. Tags of the resource."
+                  },
+                  "nullable": true
+                },
+                "platform": {
+                  "type": "object",
+                  "metadata": {
+                    "__bicep_resource_derived_type!": {
+                      "source": "Microsoft.ContainerRegistry/registries/tasks@2025-03-01-preview#properties/properties/properties/platform"
+                    },
+                    "description": "Optional. The platform properties for the task."
+                  },
+                  "nullable": true
+                },
+                "step": {
+                  "type": "object",
+                  "metadata": {
+                    "__bicep_resource_derived_type!": {
+                      "source": "Microsoft.ContainerRegistry/registries/tasks@2025-03-01-preview#properties/properties/properties/step"
+                    },
+                    "description": "Optional. The step properties for the task."
+                  },
+                  "nullable": true
+                },
+                "trigger": {
+                  "type": "object",
+                  "metadata": {
+                    "__bicep_resource_derived_type!": {
+                      "source": "Microsoft.ContainerRegistry/registries/tasks@2025-03-01-preview#properties/properties/properties/trigger"
+                    },
+                    "description": "Optional. The trigger properties for the task."
+                  },
+                  "nullable": true
+                },
+                "status": {
+                  "type": "string",
+                  "metadata": {
+                    "__bicep_resource_derived_type!": {
+                      "source": "Microsoft.ContainerRegistry/registries/tasks@2025-03-01-preview#properties/properties/properties/status"
+                    },
+                    "description": "Optional. The status of the task at the time the operation was called."
+                  },
+                  "nullable": true
+                },
+                "timeout": {
+                  "type": "int",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The timeout in seconds for the task to run before it is automatically disabled."
+                  }
+                },
+                "agentConfiguration": {
+                  "type": "object",
+                  "metadata": {
+                    "__bicep_resource_derived_type!": {
+                      "source": "Microsoft.ContainerRegistry/registries/tasks@2025-03-01-preview#properties/properties/properties/agentConfiguration"
+                    },
+                    "description": "Optional. The agent configuration for the task."
+                  },
+                  "nullable": true
+                },
+                "agentPoolName": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The name of the agent pool to run the task on. If not specified, the task will run on Microsoft-hosted agents."
+                  }
+                },
+                "isSystemTask": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Whether this is a system task or not. System tasks have some additional restrictions and are used for internal purposes by Microsoft services, such as Azure DevOps pipelines integration."
+                  }
+                },
+                "logTemplate": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The log template for the task to use when creating logs in Log Analytics."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true,
+                "description": "The type for a task."
+              }
+            },
+            "tokenType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The name of the token."
+                  }
+                },
+                "scopeMapResourceId": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The resource ID of the scope map which defines the permissions for this token."
+                  }
+                },
+                "status": {
+                  "type": "string",
+                  "metadata": {
+                    "__bicep_resource_derived_type!": {
+                      "source": "Microsoft.ContainerRegistry/registries/tokens@2025-11-01#properties/properties/properties/status"
+                    },
+                    "description": "Optional. The status of the token at the time the operation was called."
+                  },
+                  "nullable": true
+                },
+                "credentials": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/authCredentialsType"
+                  },
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The list of credentials associated with the token. Usually consists of a primary and an optional secondary credential."
+                  }
+                }
+              }
+            },
+            "webhookType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "nullable": true,
+                  "minLength": 5,
+                  "maxLength": 50,
+                  "metadata": {
+                    "description": "Optional. The name of the registry webhook."
+                  }
+                },
+                "serviceUri": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The service URI for the webhook to post notifications."
+                  }
+                },
+                "status": {
+                  "type": "string",
+                  "metadata": {
+                    "__bicep_resource_derived_type!": {
+                      "source": "Microsoft.ContainerRegistry/registries/webhooks@2025-03-01-preview#properties/properties/properties/status"
+                    },
+                    "description": "Optional. The status of the webhook at the time the operation was called."
+                  },
+                  "nullable": true
+                },
+                "action": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The list of actions that trigger the webhook to post notifications."
+                  }
+                },
+                "location": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Location for all resources."
+                  }
+                },
+                "tags": {
+                  "type": "object",
+                  "metadata": {
+                    "__bicep_resource_derived_type!": {
+                      "source": "Microsoft.ContainerRegistry/registries/webhooks@2025-03-01-preview#properties/tags"
+                    },
+                    "description": "Optional. Tags of the resource."
+                  },
+                  "nullable": true
+                },
+                "customHeaders": {
+                  "type": "object",
+                  "metadata": {
+                    "__bicep_resource_derived_type!": {
+                      "source": "Microsoft.ContainerRegistry/registries/webhooks@2025-03-01-preview#properties/properties/properties/customHeaders"
+                    },
+                    "description": "Optional. Custom headers that will be added to the webhook notifications."
+                  },
+                  "nullable": true
+                },
+                "scope": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The scope of repositories where the event can be triggered. For example, 'foo:*' means events for all tags under repository 'foo'. 'foo:bar' means events for 'foo:bar' only. 'foo' is equivalent to 'foo:latest'. Empty means all events."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true,
+                "description": "The type for a webhook."
+              }
+            },
+            "_1.privateEndpointCustomDnsConfigType": {
+              "type": "object",
+              "properties": {
+                "fqdn": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. FQDN that resolves to private endpoint IP address."
+                  }
+                },
+                "ipAddresses": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "metadata": {
+                    "description": "Required. A list of private IP addresses of the private endpoint."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
+                }
+              }
+            },
+            "_1.privateEndpointIpConfigurationType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The name of the resource that is unique within a resource group."
+                  }
+                },
+                "properties": {
+                  "type": "object",
+                  "properties": {
+                    "groupId": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The ID of a group obtained from the remote resource that this private endpoint should connect to."
+                      }
+                    },
+                    "memberName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The member name of a group obtained from the remote resource that this private endpoint should connect to."
+                      }
+                    },
+                    "privateIPAddress": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. A private IP address obtained from the private endpoint's subnet."
+                      }
+                    }
+                  },
+                  "metadata": {
+                    "description": "Required. Properties of private endpoint IP configurations."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
+                }
+              }
+            },
+            "_1.privateEndpointPrivateDnsZoneGroupType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The name of the Private DNS Zone Group."
+                  }
+                },
+                "privateDnsZoneGroupConfigs": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "nullable": true,
+                        "metadata": {
+                          "description": "Optional. The name of the private DNS Zone Group config."
+                        }
+                      },
+                      "privateDnsZoneResourceId": {
+                        "type": "string",
+                        "metadata": {
+                          "description": "Required. The resource id of the private DNS zone."
+                        }
+                      }
+                    }
+                  },
+                  "metadata": {
+                    "description": "Required. The private DNS Zone Groups to associate the Private Endpoint. A DNS Zone Group can support up to 5 DNS zones."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
+                }
+              }
+            },
+            "authCredentialsType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The name of the credential."
+                  }
+                },
+                "usernameSecretIdentifier": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. KeyVault Secret URI for accessing the username."
+                  }
+                },
+                "passwordSecretIdentifier": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. KeyVault Secret URI for accessing the password."
+                  }
+                }
+              },
+              "metadata": {
+                "description": "The type for auth credentials.",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "credential-set/main.bicep"
+                }
+              }
+            },
+            "customerManagedKeyWithAutoRotateType": {
+              "type": "object",
+              "properties": {
+                "keyVaultResourceId": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The resource ID of a key vault to reference a customer managed key for encryption from."
+                  }
+                },
+                "keyName": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The name of the customer managed key to use for encryption."
+                  }
+                },
+                "keyVersion": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The version of the customer managed key to reference for encryption. If not provided, using version as per 'autoRotationEnabled' setting."
+                  }
+                },
+                "autoRotationEnabled": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Enable or disable auto-rotating to the latest key version. Default is `true`. If set to `false`, the latest key version at the time of the deployment is used."
+                  }
+                },
+                "userAssignedIdentityResourceId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. User assigned identity to use when fetching the customer managed key. Required if no system assigned identity is available for use."
+                  }
+                }
+              },
+              "metadata": {
+                "description": "An AVM-aligned type for a customer-managed key. To be used if the resource type supports auto-rotation of the customer-managed key.",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
+                }
+              }
+            },
+            "diagnosticSettingFullType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The name of the diagnostic setting."
+                  }
+                },
+                "logCategoriesAndGroups": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "category": {
+                        "type": "string",
+                        "nullable": true,
+                        "metadata": {
+                          "description": "Optional. Name of a Diagnostic Log category for a resource type this setting is applied to. Set the specific logs to collect here."
+                        }
+                      },
+                      "categoryGroup": {
+                        "type": "string",
+                        "nullable": true,
+                        "metadata": {
+                          "description": "Optional. Name of a Diagnostic Log category group for a resource type this setting is applied to. Set to `allLogs` to collect all logs."
+                        }
+                      },
+                      "enabled": {
+                        "type": "bool",
+                        "nullable": true,
+                        "metadata": {
+                          "description": "Optional. Enable or disable the category explicitly. Default is `true`."
+                        }
+                      }
+                    }
+                  },
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The name of logs that will be streamed. \"allLogs\" includes all possible logs for the resource. Set to `[]` to disable log collection."
+                  }
+                },
+                "metricCategories": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "category": {
+                        "type": "string",
+                        "metadata": {
+                          "description": "Required. Name of a Diagnostic Metric category for a resource type this setting is applied to. Set to `AllMetrics` to collect all metrics."
+                        }
+                      },
+                      "enabled": {
+                        "type": "bool",
+                        "nullable": true,
+                        "metadata": {
+                          "description": "Optional. Enable or disable the category explicitly. Default is `true`."
+                        }
+                      }
+                    }
+                  },
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The name of metrics that will be streamed. \"allMetrics\" includes all possible metrics for the resource. Set to `[]` to disable metric collection."
+                  }
+                },
+                "logAnalyticsDestinationType": {
+                  "type": "string",
+                  "allowedValues": [
+                    "AzureDiagnostics",
+                    "Dedicated"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. A string indicating whether the export to Log Analytics should use the default destination type, i.e. AzureDiagnostics, or use a destination type."
+                  }
+                },
+                "workspaceResourceId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Resource ID of the diagnostic log analytics workspace. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub."
+                  }
+                },
+                "storageAccountResourceId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Resource ID of the diagnostic storage account. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub."
+                  }
+                },
+                "eventHubAuthorizationRuleResourceId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Resource ID of the diagnostic event hub authorization rule for the Event Hubs namespace in which the event hub should be created or streamed to."
+                  }
+                },
+                "eventHubName": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Name of the diagnostic event hub within the namespace to which logs are streamed. Without this, an event hub is created for each log category. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub."
+                  }
+                },
+                "marketplacePartnerResourceId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The full ARM resource ID of the Marketplace resource to which you would like to send Diagnostic Logs."
+                  }
+                }
+              },
+              "metadata": {
+                "description": "An AVM-aligned type for a diagnostic setting. To be used if both logs & metrics are supported by the resource provider.",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
+                }
+              }
+            },
+            "lockType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Specify the name of lock."
+                  }
+                },
+                "kind": {
+                  "type": "string",
+                  "allowedValues": [
+                    "CanNotDelete",
+                    "None",
+                    "ReadOnly"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Specify the type of lock."
+                  }
+                },
+                "notes": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Specify the notes of the lock."
+                  }
+                }
+              },
+              "metadata": {
+                "description": "An AVM-aligned type for a lock.",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
+                }
+              }
+            },
+            "managedIdentityAllType": {
+              "type": "object",
+              "properties": {
+                "systemAssigned": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Enables system assigned managed identity on the resource."
+                  }
+                },
+                "userAssignedResourceIds": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The resource ID(s) to assign to the resource. Required if a user assigned identity is used for encryption."
+                  }
+                }
+              },
+              "metadata": {
+                "description": "An AVM-aligned type for a managed identity configuration. To be used if both a system-assigned & user-assigned identities are supported by the resource provider.",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
+                }
+              }
+            },
+            "managedIdentityOnlySysAssignedType": {
+              "type": "object",
+              "properties": {
+                "systemAssigned": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Enables system assigned managed identity on the resource."
+                  }
+                }
+              },
+              "metadata": {
+                "description": "An AVM-aligned type for a managed identity configuration. To be used if only system-assigned identities are supported by the resource provider.",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
+                }
+              }
+            },
+            "privateEndpointSingleServiceType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The name of the Private Endpoint."
+                  }
+                },
+                "location": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The location to deploy the Private Endpoint to."
+                  }
+                },
+                "privateLinkServiceConnectionName": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The name of the private link connection to create."
+                  }
+                },
+                "service": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The subresource to deploy the Private Endpoint for. For example \"vault\" for a Key Vault Private Endpoint."
+                  }
+                },
+                "subnetResourceId": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. Resource ID of the subnet where the endpoint needs to be created."
+                  }
+                },
+                "resourceGroupResourceId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The resource ID of the Resource Group the Private Endpoint will be created in. If not specified, the Resource Group of the provided Virtual Network Subnet is used."
+                  }
+                },
+                "privateDnsZoneGroup": {
+                  "$ref": "#/definitions/_1.privateEndpointPrivateDnsZoneGroupType",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The private DNS Zone Group to configure for the Private Endpoint."
+                  }
+                },
+                "isManualConnection": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. If Manual Private Link Connection is required."
+                  }
+                },
+                "manualConnectionRequestMessage": {
+                  "type": "string",
+                  "nullable": true,
+                  "maxLength": 140,
+                  "metadata": {
+                    "description": "Optional. A message passed to the owner of the remote resource with the manual connection request."
+                  }
+                },
+                "customDnsConfigs": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/_1.privateEndpointCustomDnsConfigType"
+                  },
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Custom DNS configurations."
+                  }
+                },
+                "ipConfigurations": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/_1.privateEndpointIpConfigurationType"
+                  },
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. A list of IP configurations of the Private Endpoint. This will be used to map to the first-party Service endpoints."
+                  }
+                },
+                "applicationSecurityGroupResourceIds": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Application security groups in which the Private Endpoint IP configuration is included."
+                  }
+                },
+                "customNetworkInterfaceName": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The custom name of the network interface attached to the Private Endpoint."
+                  }
+                },
+                "lock": {
+                  "$ref": "#/definitions/lockType",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Specify the type of lock."
+                  }
+                },
+                "roleAssignments": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/roleAssignmentType"
+                  },
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Array of role assignments to create."
+                  }
+                },
+                "tags": {
+                  "type": "object",
+                  "nullable": true,
+                  "metadata": {
+                    "__bicep_resource_derived_type!": {
+                      "source": "Microsoft.Network/privateEndpoints@2024-07-01#properties/tags"
+                    },
+                    "description": "Optional. Tags to be applied on all resources/Resource Groups in this deployment."
+                  }
+                },
+                "enableTelemetry": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Enable/Disable usage telemetry for module."
+                  }
+                }
+              },
+              "metadata": {
+                "description": "An AVM-aligned type for a private endpoint. To be used if the private endpoint's default service / groupId can be assumed (i.e., for services that only have one Private Endpoint type like 'vault' for key vault).",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
+                }
+              }
+            },
+            "roleAssignmentType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The name (as GUID) of the role assignment. If not provided, a GUID will be generated."
+                  }
+                },
+                "roleDefinitionIdOrName": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The role to assign. You can provide either the display name of the role definition, the role definition GUID, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'."
+                  }
+                },
+                "principalId": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The principal ID of the principal (user/group/identity) to assign the role to."
+                  }
+                },
+                "principalType": {
+                  "type": "string",
+                  "allowedValues": [
+                    "Device",
+                    "ForeignGroup",
+                    "Group",
+                    "ServicePrincipal",
+                    "User"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The principal type of the assigned principal ID."
+                  }
+                },
+                "description": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The description of the role assignment."
+                  }
+                },
+                "condition": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase \"foo_storage_container\"."
+                  }
+                },
+                "conditionVersion": {
+                  "type": "string",
+                  "allowedValues": [
+                    "2.0"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Version of the condition."
+                  }
+                },
+                "delegatedManagedIdentityResourceId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The Resource Id of the delegated managed identity resource."
+                  }
+                }
+              },
+              "metadata": {
+                "description": "An AVM-aligned type for a role assignment.",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
+                }
+              }
+            }
+          },
+          "parameters": {
+            "name": {
+              "type": "string",
+              "minLength": 5,
+              "maxLength": 50,
+              "metadata": {
+                "description": "Required. Name of your Azure Container Registry."
+              }
+            },
+            "acrAdminUserEnabled": {
+              "type": "bool",
+              "defaultValue": false,
+              "metadata": {
+                "description": "Optional. Enable admin user that have push / pull permission to the registry."
+              }
+            },
+            "location": {
+              "type": "string",
+              "defaultValue": "[resourceGroup().location]",
+              "metadata": {
+                "description": "Optional. Location for all resources."
+              }
+            },
+            "roleAssignments": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/roleAssignmentType"
+              },
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Array of role assignments to create."
+              }
+            },
+            "autoGeneratedDomainNameLabelScope": {
+              "type": "string",
+              "nullable": true,
+              "allowedValues": [
+                "NoReuse",
+                "ResourceGroupReuse",
+                "SubscriptionReuse",
+                "TenantReuse",
+                "Unsecure"
+              ],
+              "metadata": {
+                "description": "Optional. The domain name label reuse scope."
+              }
+            },
+            "roleAssignmentMode": {
+              "type": "string",
+              "nullable": true,
+              "allowedValues": [
+                "AbacRepositoryPermissions",
+                "LegacyRegistryPermissions"
+              ],
+              "metadata": {
+                "description": "Optional. The registry permissions role assignment mode."
+              }
+            },
+            "acrSku": {
+              "type": "string",
+              "defaultValue": "Premium",
+              "allowedValues": [
+                "Basic",
+                "Premium",
+                "Standard"
+              ],
+              "metadata": {
+                "description": "Optional. Tier of your Azure container registry."
+              }
+            },
+            "exportPolicyStatus": {
+              "type": "string",
+              "defaultValue": "disabled",
+              "allowedValues": [
+                "disabled",
+                "enabled"
+              ],
+              "metadata": {
+                "description": "Optional. The value that indicates whether the export policy is enabled or not."
+              }
+            },
+            "quarantinePolicyStatus": {
+              "type": "string",
+              "defaultValue": "disabled",
+              "allowedValues": [
+                "disabled",
+                "enabled"
+              ],
+              "metadata": {
+                "description": "Optional. The value that indicates whether the quarantine policy is enabled or not. Note, requires the 'acrSku' to be 'Premium'."
+              }
+            },
+            "trustPolicyStatus": {
+              "type": "string",
+              "defaultValue": "disabled",
+              "allowedValues": [
+                "disabled",
+                "enabled"
+              ],
+              "metadata": {
+                "description": "Optional. The value that indicates whether the trust policy is enabled or not. Note, requires the 'acrSku' to be 'Premium'."
+              }
+            },
+            "retentionPolicyStatus": {
+              "type": "string",
+              "defaultValue": "enabled",
+              "allowedValues": [
+                "disabled",
+                "enabled"
+              ],
+              "metadata": {
+                "description": "Optional. The value that indicates whether the retention policy is enabled or not."
+              }
+            },
+            "retentionPolicyDays": {
+              "type": "int",
+              "defaultValue": 15,
+              "metadata": {
+                "description": "Optional. The number of days to retain an untagged manifest after which it gets purged."
+              }
+            },
+            "azureADAuthenticationAsArmPolicyStatus": {
+              "type": "string",
+              "defaultValue": "disabled",
+              "allowedValues": [
+                "disabled",
+                "enabled"
+              ],
+              "metadata": {
+                "description": "Optional. The value that indicates whether the policy for using ARM audience token for a container registry is enabled or not. Default is disabled."
+              }
+            },
+            "softDeletePolicyStatus": {
+              "type": "string",
+              "defaultValue": "disabled",
+              "allowedValues": [
+                "disabled",
+                "enabled"
+              ],
+              "metadata": {
+                "description": "Optional. Soft Delete policy status. Default is disabled."
+              }
+            },
+            "softDeletePolicyDays": {
+              "type": "int",
+              "defaultValue": 7,
+              "metadata": {
+                "description": "Optional. The number of days after which a soft-deleted item is permanently deleted."
+              }
+            },
+            "dataEndpointEnabled": {
+              "type": "bool",
+              "defaultValue": false,
+              "metadata": {
+                "description": "Optional. Enable a single data endpoint per region for serving data. Not relevant in case of disabled public access. Note, requires the 'acrSku' to be 'Premium'."
+              }
+            },
+            "publicNetworkAccess": {
+              "type": "string",
+              "nullable": true,
+              "allowedValues": [
+                "Enabled",
+                "Disabled"
+              ],
+              "metadata": {
+                "description": "Optional. Whether or not public network access is allowed for this resource. For security reasons it should be disabled. If not specified, it will be disabled by default if private endpoints are set and networkRuleSetIpRules are not set.  Note, requires the 'acrSku' to be 'Premium'."
+              }
+            },
+            "networkRuleBypassOptions": {
+              "type": "string",
+              "defaultValue": "AzureServices",
+              "allowedValues": [
+                "AzureServices",
+                "None"
+              ],
+              "metadata": {
+                "description": "Optional. Whether to allow trusted Azure services to access a network restricted registry."
+              }
+            },
+            "networkRuleSetDefaultAction": {
+              "type": "string",
+              "defaultValue": "Deny",
+              "allowedValues": [
+                "Allow",
+                "Deny"
+              ],
+              "metadata": {
+                "description": "Optional. The default action of allow or deny when no other rules match."
+              }
+            },
+            "networkRuleSetIpRules": {
+              "type": "array",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. The IP ACL rules. Note, requires the 'acrSku' to be 'Premium'. Set to an empty array to explicitly configure no allowed IPs."
+              }
+            },
+            "privateEndpoints": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/privateEndpointSingleServiceType"
+              },
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Configuration details for private endpoints. For security reasons, it is recommended to use private endpoints whenever possible. Note, requires the 'acrSku' to be 'Premium'."
+              }
+            },
+            "zoneRedundancy": {
+              "type": "string",
+              "defaultValue": "Enabled",
+              "allowedValues": [
+                "Disabled",
+                "Enabled"
+              ],
+              "metadata": {
+                "description": "Optional. Whether or not zone redundancy is enabled for this container registry."
+              }
+            },
+            "replications": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/replicationType"
+              },
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. All replications to create."
+              }
+            },
+            "webhooks": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/webhookType"
+              },
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. All webhooks to create."
+              }
+            },
+            "lock": {
+              "$ref": "#/definitions/lockType",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. The lock settings of the service."
+              }
+            },
+            "managedIdentities": {
+              "$ref": "#/definitions/managedIdentityAllType",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. The managed identity definition for this resource."
+              }
+            },
+            "tags": {
+              "type": "object",
+              "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.ContainerRegistry/registries@2025-04-01#properties/tags"
+                },
+                "description": "Optional. Tags of the resource."
+              },
+              "nullable": true
+            },
+            "enableTelemetry": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. Enable/Disable usage telemetry for module."
+              }
+            },
+            "diagnosticSettings": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/diagnosticSettingFullType"
+              },
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. The diagnostic settings of the service. If neither metrics nor logs are specified, all metrics & logs are configured by default. If either one is specified, the other is ignored."
+              }
+            },
+            "anonymousPullEnabled": {
+              "type": "bool",
+              "defaultValue": false,
+              "metadata": {
+                "description": "Optional. Enables registry-wide pull from unauthenticated clients. It's in preview and available in the Standard and Premium service tiers."
+              }
+            },
+            "customerManagedKey": {
+              "$ref": "#/definitions/customerManagedKeyWithAutoRotateType",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. The customer managed key definition."
+              }
+            },
+            "cacheRules": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/cacheRuleType"
+              },
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Array of Cache Rules."
+              }
+            },
+            "credentialSets": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/credentialSetType"
+              },
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Array of Credential Sets."
+              }
+            },
+            "scopeMaps": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/scopeMapsType"
+              },
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Scope maps setting."
+              }
+            },
+            "tokens": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/tokenType"
+              },
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Tokens to create for the container registry."
+              }
+            },
+            "tasks": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/taskType"
+              },
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Array of ACR Tasks to create."
+              }
+            }
+          },
+          "variables": {
+            "copy": [
+              {
+                "name": "formattedRoleAssignments",
+                "count": "[length(coalesce(parameters('roleAssignments'), createArray()))]",
+                "input": "[union(coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')], createObject('roleDefinitionId', coalesce(tryGet(variables('builtInRoleNames'), coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName), if(contains(coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName, '/providers/Microsoft.Authorization/roleDefinitions/'), coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName)))))]"
+              }
+            ],
+            "enableReferencedModulesTelemetry": false,
+            "formattedUserAssignedIdentities": "[reduce(map(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createArray()), lambda('id', createObject(format('{0}', lambdaVariables('id')), createObject()))), createObject(), lambda('cur', 'next', union(lambdaVariables('cur'), lambdaVariables('next'))))]",
+            "identity": "[if(not(empty(parameters('managedIdentities'))), createObject('type', if(coalesce(tryGet(parameters('managedIdentities'), 'systemAssigned'), false()), if(not(empty(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createObject()))), 'SystemAssigned, UserAssigned', 'SystemAssigned'), if(not(empty(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createObject()))), 'UserAssigned', 'None')), 'userAssignedIdentities', if(not(empty(variables('formattedUserAssignedIdentities'))), variables('formattedUserAssignedIdentities'), null())), null())]",
+            "builtInRoleNames": {
+              "AcrDelete": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'c2f4ef07-c644-48eb-af81-4b1b4947fb11')]",
+              "AcrImageSigner": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '6cef56e8-d556-48e5-a04f-b8e64114680f')]",
+              "AcrPull": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d')]",
+              "AcrPush": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8311e382-0749-4cb8-b61a-304f252e45ec')]",
+              "AcrQuarantineReader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'cdda3590-29a3-44f6-95f2-9f980659eb04')]",
+              "AcrQuarantineWriter": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'c8d4ff99-41c3-41a8-9f60-21dfdad59608')]",
+              "Container Registry Repository Catalog Lister": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'bfdb9389-c9a5-478a-bb2f-ba9ca092c3c7')]",
+              "Container Registry Repository Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '2efddaa5-3f1f-4df3-97df-af3f13818f4c')]",
+              "Container Registry Repository Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b93aa761-3e63-49ed-ac28-beffa264f7ac')]",
+              "Container Registry Repository Writer": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '2a1e307c-b015-4ebd-883e-5b7698a07328')]",
+              "Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
+              "Owner": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')]",
+              "Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')]",
+              "Role Based Access Control Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f58310d9-a9f6-439a-9e8d-f62e7b41a168')]",
+              "User Access Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9')]"
+            },
+            "publicNetworkAccessMode": "[if(not(empty(parameters('publicNetworkAccess'))), parameters('publicNetworkAccess'), if(and(not(empty(parameters('privateEndpoints'))), empty(parameters('networkRuleSetIpRules'))), 'Disabled', null()))]",
+            "shouldConfigureNetworkRuleSet": "[or(not(equals(parameters('networkRuleSetIpRules'), null())), and(equals(variables('publicNetworkAccessMode'), 'Enabled'), equals(parameters('networkRuleSetDefaultAction'), 'Deny')))]"
+          },
+          "resources": {
+            "cMKKeyVault::cMKKey": {
+              "condition": "[and(not(empty(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'))), and(not(empty(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'))), not(empty(tryGet(parameters('customerManagedKey'), 'keyName')))))]",
+              "existing": true,
+              "type": "Microsoft.KeyVault/vaults/keys",
+              "apiVersion": "2024-11-01",
+              "subscriptionId": "[split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')[2]]",
+              "resourceGroup": "[split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')[4]]",
+              "name": "[format('{0}/{1}', last(split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')), tryGet(parameters('customerManagedKey'), 'keyName'))]"
+            },
+            "avmTelemetry": {
+              "condition": "[parameters('enableTelemetry')]",
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2025-04-01",
+              "name": "[format('46d3xbcp.res.containerregistry-registry.{0}.{1}', replace('0.12.1', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
+              "properties": {
+                "mode": "Incremental",
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "resources": [],
+                  "outputs": {
+                    "telemetry": {
+                      "type": "String",
+                      "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                    }
+                  }
+                }
+              }
+            },
+            "cMKKeyVault": {
+              "condition": "[not(empty(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId')))]",
+              "existing": true,
+              "type": "Microsoft.KeyVault/vaults",
+              "apiVersion": "2024-11-01",
+              "subscriptionId": "[split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')[2]]",
+              "resourceGroup": "[split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')[4]]",
+              "name": "[last(split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/'))]"
+            },
+            "cMKUserAssignedIdentity": {
+              "condition": "[not(empty(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId')))]",
+              "existing": true,
+              "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
+              "apiVersion": "2024-11-30",
+              "subscriptionId": "[split(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), '/')[2]]",
+              "resourceGroup": "[split(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), '/')[4]]",
+              "name": "[last(split(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), '/'))]"
+            },
+            "registry": {
+              "type": "Microsoft.ContainerRegistry/registries",
+              "apiVersion": "2025-06-01-preview",
+              "name": "[parameters('name')]",
+              "location": "[parameters('location')]",
+              "identity": "[variables('identity')]",
+              "tags": "[parameters('tags')]",
+              "sku": {
+                "name": "[parameters('acrSku')]"
+              },
+              "properties": {
+                "anonymousPullEnabled": "[parameters('anonymousPullEnabled')]",
+                "adminUserEnabled": "[parameters('acrAdminUserEnabled')]",
+                "autoGeneratedDomainNameLabelScope": "[parameters('autoGeneratedDomainNameLabelScope')]",
+                "roleAssignmentMode": "[parameters('roleAssignmentMode')]",
+                "encryption": "[if(not(empty(parameters('customerManagedKey'))), createObject('status', 'enabled', 'keyVaultProperties', createObject('identity', if(not(empty(coalesce(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), ''))), reference('cMKUserAssignedIdentity').clientId, null()), 'keyIdentifier', if(not(empty(tryGet(parameters('customerManagedKey'), 'keyVersion'))), format('{0}/{1}', reference('cMKKeyVault::cMKKey').keyUri, tryGet(parameters('customerManagedKey'), 'keyVersion')), if(coalesce(tryGet(parameters('customerManagedKey'), 'autoRotationEnabled'), true()), reference('cMKKeyVault::cMKKey').keyUri, reference('cMKKeyVault::cMKKey').keyUriWithVersion)))), null())]",
+                "policies": {
+                  "azureADAuthenticationAsArmPolicy": {
+                    "status": "[parameters('azureADAuthenticationAsArmPolicyStatus')]"
+                  },
+                  "exportPolicy": "[if(equals(parameters('acrSku'), 'Premium'), createObject('status', parameters('exportPolicyStatus')), null())]",
+                  "quarantinePolicy": "[if(equals(parameters('acrSku'), 'Premium'), createObject('status', parameters('quarantinePolicyStatus')), null())]",
+                  "trustPolicy": "[if(equals(parameters('acrSku'), 'Premium'), createObject('type', 'Notary', 'status', parameters('trustPolicyStatus')), null())]",
+                  "retentionPolicy": "[if(equals(parameters('acrSku'), 'Premium'), createObject('days', parameters('retentionPolicyDays'), 'status', parameters('retentionPolicyStatus')), null())]",
+                  "softDeletePolicy": {
+                    "retentionDays": "[parameters('softDeletePolicyDays')]",
+                    "status": "[parameters('softDeletePolicyStatus')]"
+                  }
+                },
+                "dataEndpointEnabled": "[parameters('dataEndpointEnabled')]",
+                "publicNetworkAccess": "[variables('publicNetworkAccessMode')]",
+                "networkRuleBypassOptions": "[parameters('networkRuleBypassOptions')]",
+                "networkRuleSet": "[if(variables('shouldConfigureNetworkRuleSet'), createObject('defaultAction', parameters('networkRuleSetDefaultAction'), 'ipRules', coalesce(parameters('networkRuleSetIpRules'), createArray())), null())]",
+                "zoneRedundancy": "[if(equals(parameters('acrSku'), 'Premium'), parameters('zoneRedundancy'), null())]"
+              },
+              "dependsOn": [
+                "cMKKeyVault::cMKKey",
+                "cMKUserAssignedIdentity"
+              ]
+            },
+            "registry_lock": {
+              "condition": "[and(not(empty(coalesce(parameters('lock'), createObject()))), not(equals(tryGet(parameters('lock'), 'kind'), 'None')))]",
+              "type": "Microsoft.Authorization/locks",
+              "apiVersion": "2020-05-01",
+              "scope": "[resourceId('Microsoft.ContainerRegistry/registries', parameters('name'))]",
+              "name": "[coalesce(tryGet(parameters('lock'), 'name'), format('lock-{0}', parameters('name')))]",
+              "properties": {
+                "level": "[coalesce(tryGet(parameters('lock'), 'kind'), '')]",
+                "notes": "[coalesce(tryGet(parameters('lock'), 'notes'), if(equals(tryGet(parameters('lock'), 'kind'), 'CanNotDelete'), 'Cannot delete resource or child resources.', 'Cannot delete or modify the resource or child resources.'))]"
+              },
+              "dependsOn": [
+                "registry"
+              ]
+            },
+            "registry_diagnosticSettings": {
+              "copy": {
+                "name": "registry_diagnosticSettings",
+                "count": "[length(coalesce(parameters('diagnosticSettings'), createArray()))]"
+              },
+              "type": "Microsoft.Insights/diagnosticSettings",
+              "apiVersion": "2021-05-01-preview",
+              "scope": "[resourceId('Microsoft.ContainerRegistry/registries', parameters('name'))]",
+              "name": "[coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'name'), format('{0}-diagnosticSettings', parameters('name')))]",
+              "properties": {
+                "copy": [
+                  {
+                    "name": "metrics",
+                    "count": "[length(coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'metricCategories'), if(empty(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'logCategoriesAndGroups')), createArray(createObject('category', 'AllMetrics')), createArray())))]",
+                    "input": {
+                      "category": "[coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'metricCategories'), if(empty(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'logCategoriesAndGroups')), createArray(createObject('category', 'AllMetrics')), createArray()))[copyIndex('metrics')].category]",
+                      "enabled": "[coalesce(tryGet(coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'metricCategories'), if(empty(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'logCategoriesAndGroups')), createArray(createObject('category', 'AllMetrics')), createArray()))[copyIndex('metrics')], 'enabled'), true())]",
+                      "timeGrain": null
+                    }
+                  },
+                  {
+                    "name": "logs",
+                    "count": "[length(coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'logCategoriesAndGroups'), if(empty(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'metricCategories')), createArray(createObject('categoryGroup', 'allLogs')), createArray())))]",
+                    "input": {
+                      "categoryGroup": "[tryGet(coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'logCategoriesAndGroups'), if(empty(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'metricCategories')), createArray(createObject('categoryGroup', 'allLogs')), createArray()))[copyIndex('logs')], 'categoryGroup')]",
+                      "category": "[tryGet(coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'logCategoriesAndGroups'), if(empty(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'metricCategories')), createArray(createObject('categoryGroup', 'allLogs')), createArray()))[copyIndex('logs')], 'category')]",
+                      "enabled": "[coalesce(tryGet(coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'logCategoriesAndGroups'), if(empty(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'metricCategories')), createArray(createObject('categoryGroup', 'allLogs')), createArray()))[copyIndex('logs')], 'enabled'), true())]"
+                    }
+                  }
+                ],
+                "storageAccountId": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'storageAccountResourceId')]",
+                "workspaceId": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'workspaceResourceId')]",
+                "eventHubAuthorizationRuleId": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'eventHubAuthorizationRuleResourceId')]",
+                "eventHubName": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'eventHubName')]",
+                "marketplacePartnerId": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'marketplacePartnerResourceId')]",
+                "logAnalyticsDestinationType": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'logAnalyticsDestinationType')]"
+              },
+              "dependsOn": [
+                "registry"
+              ]
+            },
+            "registry_roleAssignments": {
+              "copy": {
+                "name": "registry_roleAssignments",
+                "count": "[length(coalesce(variables('formattedRoleAssignments'), createArray()))]"
+              },
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "scope": "[resourceId('Microsoft.ContainerRegistry/registries', parameters('name'))]",
+              "name": "[coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'name'), guid(resourceId('Microsoft.ContainerRegistry/registries', parameters('name')), coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId, coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId))]",
+              "properties": {
+                "roleDefinitionId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId]",
+                "principalId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId]",
+                "description": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'description')]",
+                "principalType": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'principalType')]",
+                "condition": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'condition')]",
+                "conditionVersion": "[if(not(empty(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'condition'))), coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'conditionVersion'), '2.0'), null())]",
+                "delegatedManagedIdentityResourceId": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'delegatedManagedIdentityResourceId')]"
+              },
+              "dependsOn": [
+                "registry"
+              ]
+            },
+            "registry_scopeMaps": {
+              "copy": {
+                "name": "registry_scopeMaps",
+                "count": "[length(coalesce(parameters('scopeMaps'), createArray()))]"
+              },
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2025-04-01",
+              "name": "[format('{0}-Registry-Scope-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "name": {
+                    "value": "[tryGet(coalesce(parameters('scopeMaps'), createArray())[copyIndex()], 'name')]"
+                  },
+                  "actions": {
+                    "value": "[coalesce(parameters('scopeMaps'), createArray())[copyIndex()].actions]"
+                  },
+                  "description": {
+                    "value": "[tryGet(coalesce(parameters('scopeMaps'), createArray())[copyIndex()], 'description')]"
+                  },
+                  "registryName": {
+                    "value": "[parameters('name')]"
+                  },
+                  "enableTelemetry": {
+                    "value": "[variables('enableReferencedModulesTelemetry')]"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "languageVersion": "2.0",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.42.1.51946",
+                      "templateHash": "3787322352564227867"
+                    },
+                    "name": "Container Registries scope maps",
+                    "description": "This module deploys an Azure Container Registry (ACR) scope map."
+                  },
+                  "parameters": {
+                    "registryName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Conditional. The name of the parent registry. Required if the template is used in a standalone deployment."
+                      }
+                    },
+                    "name": {
+                      "type": "string",
+                      "defaultValue": "[format('{0}-scopemaps', parameters('registryName'))]",
+                      "metadata": {
+                        "description": "Optional. The name of the scope map."
+                      }
+                    },
+                    "actions": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "metadata": {
+                        "description": "Required. The list of scoped permissions for registry artifacts."
+                      }
+                    },
+                    "description": {
+                      "type": "string",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. The user friendly description of the scope map."
+                      }
+                    },
+                    "enableTelemetry": {
+                      "type": "bool",
+                      "defaultValue": true,
+                      "metadata": {
+                        "description": "Optional. Enable/Disable usage telemetry for module."
+                      }
+                    }
+                  },
+                  "resources": {
+                    "avmTelemetry": {
+                      "condition": "[parameters('enableTelemetry')]",
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2025-04-01",
+                      "name": "[format('46d3xbcp.res.containerregistry-registry-scopemap.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name), 0, 4))]",
+                      "properties": {
+                        "mode": "Incremental",
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                          "contentVersion": "1.0.0.0",
+                          "resources": [],
+                          "outputs": {
+                            "telemetry": {
+                              "type": "String",
+                              "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "registry": {
+                      "existing": true,
+                      "type": "Microsoft.ContainerRegistry/registries",
+                      "apiVersion": "2025-11-01",
+                      "name": "[parameters('registryName')]"
+                    },
+                    "scopeMap": {
+                      "type": "Microsoft.ContainerRegistry/registries/scopeMaps",
+                      "apiVersion": "2025-11-01",
+                      "name": "[format('{0}/{1}', parameters('registryName'), parameters('name'))]",
+                      "properties": {
+                        "actions": "[parameters('actions')]",
+                        "description": "[parameters('description')]"
+                      }
+                    }
+                  },
+                  "outputs": {
+                    "name": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The name of the scope map."
+                      },
+                      "value": "[parameters('name')]"
+                    },
+                    "resourceGroupName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The name of the resource group the scope map was created in."
+                      },
+                      "value": "[resourceGroup().name]"
+                    },
+                    "resourceId": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The resource ID of the scope map."
+                      },
+                      "value": "[resourceId('Microsoft.ContainerRegistry/registries/scopeMaps', parameters('registryName'), parameters('name'))]"
+                    }
+                  }
+                }
+              },
+              "dependsOn": [
+                "registry"
+              ]
+            },
+            "registry_replications": {
+              "copy": {
+                "name": "registry_replications",
+                "count": "[length(coalesce(parameters('replications'), createArray()))]"
+              },
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2025-04-01",
+              "name": "[format('{0}-Registry-Replication-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "name": {
+                    "value": "[coalesce(parameters('replications'), createArray())[copyIndex()].name]"
+                  },
+                  "registryName": {
+                    "value": "[parameters('name')]"
+                  },
+                  "location": {
+                    "value": "[coalesce(parameters('replications'), createArray())[copyIndex()].location]"
+                  },
+                  "regionEndpointEnabled": {
+                    "value": "[tryGet(coalesce(parameters('replications'), createArray())[copyIndex()], 'regionEndpointEnabled')]"
+                  },
+                  "zoneRedundancy": {
+                    "value": "[tryGet(coalesce(parameters('replications'), createArray())[copyIndex()], 'zoneRedundancy')]"
+                  },
+                  "tags": {
+                    "value": "[coalesce(tryGet(coalesce(parameters('replications'), createArray())[copyIndex()], 'tags'), parameters('tags'))]"
+                  },
+                  "enableTelemetry": {
+                    "value": "[variables('enableReferencedModulesTelemetry')]"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "languageVersion": "2.0",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.42.1.51946",
+                      "templateHash": "6219097750044645017"
+                    },
+                    "name": "Azure Container Registry (ACR) Replications",
+                    "description": "This module deploys an Azure Container Registry (ACR) Replication."
+                  },
+                  "parameters": {
+                    "registryName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Conditional. The name of the parent registry. Required if the template is used in a standalone deployment."
+                      }
+                    },
+                    "name": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The name of the replication."
+                      }
+                    },
+                    "location": {
+                      "type": "string",
+                      "defaultValue": "[resourceGroup().location]",
+                      "metadata": {
+                        "description": "Optional. Location for all resources."
+                      }
+                    },
+                    "tags": {
+                      "type": "object",
+                      "metadata": {
+                        "__bicep_resource_derived_type!": {
+                          "source": "Microsoft.ContainerRegistry/registries/replications@2025-11-01#properties/tags"
+                        },
+                        "description": "Optional. Tags of the resource."
+                      },
+                      "nullable": true
+                    },
+                    "regionEndpointEnabled": {
+                      "type": "bool",
+                      "defaultValue": true,
+                      "metadata": {
+                        "description": "Optional. Specifies whether the replication regional endpoint is enabled. Requests will not be routed to a replication whose regional endpoint is disabled, however its data will continue to be synced with other replications."
+                      }
+                    },
+                    "zoneRedundancy": {
+                      "type": "string",
+                      "defaultValue": "Disabled",
+                      "allowedValues": [
+                        "Disabled",
+                        "Enabled"
+                      ],
+                      "metadata": {
+                        "description": "Optional. Whether or not zone redundancy is enabled for this container registry."
+                      }
+                    },
+                    "enableTelemetry": {
+                      "type": "bool",
+                      "defaultValue": true,
+                      "metadata": {
+                        "description": "Optional. Enable/Disable usage telemetry for module."
+                      }
+                    }
+                  },
+                  "resources": {
+                    "avmTelemetry": {
+                      "condition": "[parameters('enableTelemetry')]",
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2025-04-01",
+                      "name": "[format('46d3xbcp.res.containerregistry-registry-repl.{0}.{1}', replace('0.1.1', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
+                      "properties": {
+                        "mode": "Incremental",
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                          "contentVersion": "1.0.0.0",
+                          "resources": [],
+                          "outputs": {
+                            "telemetry": {
+                              "type": "String",
+                              "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "registry": {
+                      "existing": true,
+                      "type": "Microsoft.ContainerRegistry/registries",
+                      "apiVersion": "2025-11-01",
+                      "name": "[parameters('registryName')]"
+                    },
+                    "replication": {
+                      "type": "Microsoft.ContainerRegistry/registries/replications",
+                      "apiVersion": "2025-11-01",
+                      "name": "[format('{0}/{1}', parameters('registryName'), parameters('name'))]",
+                      "location": "[parameters('location')]",
+                      "tags": "[parameters('tags')]",
+                      "properties": {
+                        "regionEndpointEnabled": "[parameters('regionEndpointEnabled')]",
+                        "zoneRedundancy": "[parameters('zoneRedundancy')]"
+                      }
+                    }
+                  },
+                  "outputs": {
+                    "name": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The name of the replication."
+                      },
+                      "value": "[parameters('name')]"
+                    },
+                    "resourceId": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The resource ID of the replication."
+                      },
+                      "value": "[resourceId('Microsoft.ContainerRegistry/registries/replications', parameters('registryName'), parameters('name'))]"
+                    },
+                    "resourceGroupName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The name of the resource group the replication was created in."
+                      },
+                      "value": "[resourceGroup().name]"
+                    },
+                    "location": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The location the resource was deployed into."
+                      },
+                      "value": "[reference('replication', '2025-11-01', 'full').location]"
+                    }
+                  }
+                }
+              },
+              "dependsOn": [
+                "registry"
+              ]
+            },
+            "registry_credentialSets": {
+              "copy": {
+                "name": "registry_credentialSets",
+                "count": "[length(coalesce(parameters('credentialSets'), createArray()))]"
+              },
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2025-04-01",
+              "name": "[format('{0}-Registry-CredentialSet-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "name": {
+                    "value": "[coalesce(parameters('credentialSets'), createArray())[copyIndex()].name]"
+                  },
+                  "registryName": {
+                    "value": "[parameters('name')]"
+                  },
+                  "managedIdentities": {
+                    "value": "[coalesce(parameters('credentialSets'), createArray())[copyIndex()].managedIdentities]"
+                  },
+                  "authCredentials": {
+                    "value": "[coalesce(parameters('credentialSets'), createArray())[copyIndex()].authCredentials]"
+                  },
+                  "loginServer": {
+                    "value": "[coalesce(parameters('credentialSets'), createArray())[copyIndex()].loginServer]"
+                  },
+                  "enableTelemetry": {
+                    "value": "[variables('enableReferencedModulesTelemetry')]"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "languageVersion": "2.0",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.42.1.51946",
+                      "templateHash": "13412699468141336519"
+                    },
+                    "name": "Container Registries Credential Sets",
+                    "description": "This module deploys an ACR Credential Set."
+                  },
+                  "definitions": {
+                    "authCredentialsType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The name of the credential."
+                          }
+                        },
+                        "usernameSecretIdentifier": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. KeyVault Secret URI for accessing the username."
+                          }
+                        },
+                        "passwordSecretIdentifier": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. KeyVault Secret URI for accessing the password."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "__bicep_export!": true,
+                        "description": "The type for auth credentials."
+                      }
+                    },
+                    "managedIdentityOnlySysAssignedType": {
+                      "type": "object",
+                      "properties": {
+                        "systemAssigned": {
+                          "type": "bool",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Enables system assigned managed identity on the resource."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "description": "An AVM-aligned type for a managed identity configuration. To be used if only system-assigned identities are supported by the resource provider.",
+                        "__bicep_imported_from!": {
+                          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
+                        }
+                      }
+                    }
+                  },
+                  "parameters": {
+                    "registryName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Conditional. The name of the parent registry. Required if the template is used in a standalone deployment."
+                      }
+                    },
+                    "name": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The name of the credential set."
+                      }
+                    },
+                    "managedIdentities": {
+                      "$ref": "#/definitions/managedIdentityOnlySysAssignedType",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. The managed identity definition for this resource."
+                      }
+                    },
+                    "authCredentials": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/authCredentialsType"
+                      },
+                      "metadata": {
+                        "description": "Required. List of authentication credentials stored for an upstream. Usually consists of a primary and an optional secondary credential."
+                      }
+                    },
+                    "loginServer": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The credentials are stored for this upstream or login server."
+                      }
+                    },
+                    "enableTelemetry": {
+                      "type": "bool",
+                      "defaultValue": true,
+                      "metadata": {
+                        "description": "Optional. Enable/Disable usage telemetry for module."
+                      }
+                    }
+                  },
+                  "resources": {
+                    "avmTelemetry": {
+                      "condition": "[parameters('enableTelemetry')]",
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2025-04-01",
+                      "name": "[format('46d3xbcp.res.containerregistry-registry-credset.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name), 0, 4))]",
+                      "properties": {
+                        "mode": "Incremental",
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                          "contentVersion": "1.0.0.0",
+                          "resources": [],
+                          "outputs": {
+                            "telemetry": {
+                              "type": "String",
+                              "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "registry": {
+                      "existing": true,
+                      "type": "Microsoft.ContainerRegistry/registries",
+                      "apiVersion": "2025-11-01",
+                      "name": "[parameters('registryName')]"
+                    },
+                    "credentialSet": {
+                      "type": "Microsoft.ContainerRegistry/registries/credentialSets",
+                      "apiVersion": "2025-11-01",
+                      "name": "[format('{0}/{1}', parameters('registryName'), parameters('name'))]",
+                      "identity": "[if(not(empty(parameters('managedIdentities'))), createObject('type', if(coalesce(tryGet(parameters('managedIdentities'), 'systemAssigned'), false()), 'SystemAssigned', null())), null())]",
+                      "properties": {
+                        "authCredentials": "[parameters('authCredentials')]",
+                        "loginServer": "[parameters('loginServer')]"
+                      }
+                    }
+                  },
+                  "outputs": {
+                    "name": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The Name of the Credential Set."
+                      },
+                      "value": "[parameters('name')]"
+                    },
+                    "resourceGroupName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The name of the Credential Set."
+                      },
+                      "value": "[resourceGroup().name]"
+                    },
+                    "resourceId": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The resource ID of the Credential Set."
+                      },
+                      "value": "[resourceId('Microsoft.ContainerRegistry/registries/credentialSets', parameters('registryName'), parameters('name'))]"
+                    },
+                    "systemAssignedMIPrincipalId": {
+                      "type": "string",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "The principal ID of the system assigned identity."
+                      },
+                      "value": "[tryGet(tryGet(reference('credentialSet', '2025-11-01', 'full'), 'identity'), 'principalId')]"
+                    }
+                  }
+                }
+              },
+              "dependsOn": [
+                "registry"
+              ]
+            },
+            "registry_cacheRules": {
+              "copy": {
+                "name": "registry_cacheRules",
+                "count": "[length(coalesce(parameters('cacheRules'), createArray()))]"
+              },
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2025-04-01",
+              "name": "[format('{0}-Registry-Cache-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "registryName": {
+                    "value": "[parameters('name')]"
+                  },
+                  "sourceRepository": {
+                    "value": "[coalesce(parameters('cacheRules'), createArray())[copyIndex()].sourceRepository]"
+                  },
+                  "name": {
+                    "value": "[tryGet(coalesce(parameters('cacheRules'), createArray())[copyIndex()], 'name')]"
+                  },
+                  "targetRepository": {
+                    "value": "[coalesce(tryGet(coalesce(parameters('cacheRules'), createArray())[copyIndex()], 'targetRepository'), coalesce(parameters('cacheRules'), createArray())[copyIndex()].sourceRepository)]"
+                  },
+                  "credentialSetResourceId": {
+                    "value": "[tryGet(coalesce(parameters('cacheRules'), createArray())[copyIndex()], 'credentialSetResourceId')]"
+                  },
+                  "enableTelemetry": {
+                    "value": "[variables('enableReferencedModulesTelemetry')]"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "languageVersion": "2.0",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.42.1.51946",
+                      "templateHash": "1319901650921923538"
+                    },
+                    "name": "Container Registry Cache",
+                    "description": "The cache for Azure Container Registry (Preview) feature allows users to cache container images in a private container registry. Cache for ACR, is a preview feature available in Basic, Standard, and Premium service tiers ([ref](https://learn.microsoft.com/en-us/azure/container-registry/tutorial-registry-cache))."
+                  },
+                  "parameters": {
+                    "registryName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Conditional. The name of the parent registry. Required if the template is used in a standalone deployment."
+                      }
+                    },
+                    "name": {
+                      "type": "string",
+                      "defaultValue": "[replace(replace(replace(parameters('sourceRepository'), '/', '-'), '.', '-'), '*', '')]",
+                      "metadata": {
+                        "description": "Optional. The name of the cache rule. Will be derived from the source repository name if not defined."
+                      }
+                    },
+                    "sourceRepository": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. Source repository pulled from upstream."
+                      }
+                    },
+                    "targetRepository": {
+                      "type": "string",
+                      "defaultValue": "[parameters('sourceRepository')]",
+                      "metadata": {
+                        "description": "Optional. Target repository specified in docker pull command. E.g.: docker pull myregistry.azurecr.io/{targetRepository}:{tag}."
+                      }
+                    },
+                    "credentialSetResourceId": {
+                      "type": "string",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. The resource ID of the credential store which is associated with the cache rule. Required only when pulling from authenticated upstream registries (e.g., Docker Hub). Omit for anonymous public registries such as MCR (mcr.microsoft.com)."
+                      }
+                    },
+                    "enableTelemetry": {
+                      "type": "bool",
+                      "defaultValue": true,
+                      "metadata": {
+                        "description": "Optional. Enable/Disable usage telemetry for module."
+                      }
+                    }
+                  },
+                  "resources": {
+                    "avmTelemetry": {
+                      "condition": "[parameters('enableTelemetry')]",
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2025-04-01",
+                      "name": "[format('46d3xbcp.res.containerregistry-registry-cacherule.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name), 0, 4))]",
+                      "properties": {
+                        "mode": "Incremental",
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                          "contentVersion": "1.0.0.0",
+                          "resources": [],
+                          "outputs": {
+                            "telemetry": {
+                              "type": "String",
+                              "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "registry": {
+                      "existing": true,
+                      "type": "Microsoft.ContainerRegistry/registries",
+                      "apiVersion": "2025-11-01",
+                      "name": "[parameters('registryName')]"
+                    },
+                    "cacheRule": {
+                      "type": "Microsoft.ContainerRegistry/registries/cacheRules",
+                      "apiVersion": "2025-11-01",
+                      "name": "[format('{0}/{1}', parameters('registryName'), parameters('name'))]",
+                      "properties": {
+                        "sourceRepository": "[parameters('sourceRepository')]",
+                        "targetRepository": "[parameters('targetRepository')]",
+                        "credentialSetResourceId": "[parameters('credentialSetResourceId')]"
+                      }
+                    }
+                  },
+                  "outputs": {
+                    "name": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The Name of the Cache Rule."
+                      },
+                      "value": "[parameters('name')]"
+                    },
+                    "resourceGroupName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The name of the Cache Rule."
+                      },
+                      "value": "[resourceGroup().name]"
+                    },
+                    "resourceId": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The resource ID of the Cache Rule."
+                      },
+                      "value": "[resourceId('Microsoft.ContainerRegistry/registries/cacheRules', parameters('registryName'), parameters('name'))]"
+                    }
+                  }
+                }
+              },
+              "dependsOn": [
+                "registry",
+                "registry_credentialSets"
+              ]
+            },
+            "registry_tokens": {
+              "copy": {
+                "name": "registry_tokens",
+                "count": "[length(coalesce(parameters('tokens'), createArray()))]"
+              },
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2025-04-01",
+              "name": "[format('{0}-Registry-Token-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "name": {
+                    "value": "[coalesce(parameters('tokens'), createArray())[copyIndex()].name]"
+                  },
+                  "registryName": {
+                    "value": "[parameters('name')]"
+                  },
+                  "scopeMapResourceId": {
+                    "value": "[coalesce(parameters('tokens'), createArray())[copyIndex()].scopeMapResourceId]"
+                  },
+                  "status": {
+                    "value": "[tryGet(coalesce(parameters('tokens'), createArray())[copyIndex()], 'status')]"
+                  },
+                  "credentials": {
+                    "value": "[tryGet(coalesce(parameters('tokens'), createArray())[copyIndex()], 'credentials')]"
+                  },
+                  "enableTelemetry": {
+                    "value": "[variables('enableReferencedModulesTelemetry')]"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "languageVersion": "2.0",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.42.1.51946",
+                      "templateHash": "5970335582661416899"
+                    },
+                    "name": "Container Registries Tokens",
+                    "description": "Deploys an Azure Container Registry (ACR) Token."
+                  },
+                  "parameters": {
+                    "registryName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Conditional. The name of the parent registry. Required if the template is used in a standalone deployment."
+                      }
+                    },
+                    "name": {
+                      "type": "string",
+                      "minLength": 5,
+                      "maxLength": 50,
+                      "metadata": {
+                        "description": "Required. The name of the token."
+                      }
+                    },
+                    "scopeMapResourceId": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The resource ID of the scope map to which the token will be associated with."
+                      }
+                    },
+                    "status": {
+                      "type": "string",
+                      "defaultValue": "enabled",
+                      "allowedValues": [
+                        "disabled",
+                        "enabled"
+                      ],
+                      "metadata": {
+                        "description": "Optional. The status of the token. Default is enabled."
+                      }
+                    },
+                    "credentials": {
+                      "type": "object",
+                      "metadata": {
+                        "__bicep_resource_derived_type!": {
+                          "source": "Microsoft.ContainerRegistry/registries/tokens@2025-11-01#properties/properties/properties/credentials"
+                        },
+                        "description": "Optional. The credentials associated with the token for authentication."
+                      },
+                      "nullable": true
+                    },
+                    "enableTelemetry": {
+                      "type": "bool",
+                      "defaultValue": true,
+                      "metadata": {
+                        "description": "Optional. Enable/Disable usage telemetry for module."
+                      }
+                    }
+                  },
+                  "resources": {
+                    "avmTelemetry": {
+                      "condition": "[parameters('enableTelemetry')]",
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2025-04-01",
+                      "name": "[format('46d3xbcp.res.containerregistry-registry-token.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name), 0, 4))]",
+                      "properties": {
+                        "mode": "Incremental",
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                          "contentVersion": "1.0.0.0",
+                          "resources": [],
+                          "outputs": {
+                            "telemetry": {
+                              "type": "String",
+                              "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "registry": {
+                      "existing": true,
+                      "type": "Microsoft.ContainerRegistry/registries",
+                      "apiVersion": "2025-11-01",
+                      "name": "[parameters('registryName')]"
+                    },
+                    "token": {
+                      "type": "Microsoft.ContainerRegistry/registries/tokens",
+                      "apiVersion": "2025-11-01",
+                      "name": "[format('{0}/{1}', parameters('registryName'), parameters('name'))]",
+                      "properties": {
+                        "scopeMapId": "[parameters('scopeMapResourceId')]",
+                        "status": "[parameters('status')]",
+                        "credentials": "[if(not(empty(coalesce(parameters('credentials'), createArray()))), createObject('certificates', tryGet(parameters('credentials'), 'certificates'), 'passwords', tryGet(parameters('credentials'), 'passwords')), null())]"
+                      }
+                    }
+                  },
+                  "outputs": {
+                    "name": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The name of the token."
+                      },
+                      "value": "[parameters('name')]"
+                    },
+                    "resourceGroupName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The name of the resource group the token was created in."
+                      },
+                      "value": "[resourceGroup().name]"
+                    },
+                    "resourceId": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The resource ID of the token."
+                      },
+                      "value": "[resourceId('Microsoft.ContainerRegistry/registries/tokens', parameters('registryName'), parameters('name'))]"
+                    }
+                  }
+                }
+              },
+              "dependsOn": [
+                "registry",
+                "registry_scopeMaps"
+              ]
+            },
+            "registry_tasks": {
+              "copy": {
+                "name": "registry_tasks",
+                "count": "[length(coalesce(parameters('tasks'), createArray()))]"
+              },
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2025-04-01",
+              "name": "[format('{0}-Registry-Task-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "registryName": {
+                    "value": "[parameters('name')]"
+                  },
+                  "name": {
+                    "value": "[coalesce(parameters('tasks'), createArray())[copyIndex()].name]"
+                  },
+                  "location": {
+                    "value": "[coalesce(tryGet(coalesce(parameters('tasks'), createArray())[copyIndex()], 'location'), parameters('location'))]"
+                  },
+                  "tags": {
+                    "value": "[coalesce(tryGet(coalesce(parameters('tasks'), createArray())[copyIndex()], 'tags'), parameters('tags'))]"
+                  },
+                  "platform": {
+                    "value": "[tryGet(coalesce(parameters('tasks'), createArray())[copyIndex()], 'platform')]"
+                  },
+                  "step": {
+                    "value": "[tryGet(coalesce(parameters('tasks'), createArray())[copyIndex()], 'step')]"
+                  },
+                  "trigger": {
+                    "value": "[tryGet(coalesce(parameters('tasks'), createArray())[copyIndex()], 'trigger')]"
+                  },
+                  "status": {
+                    "value": "[tryGet(coalesce(parameters('tasks'), createArray())[copyIndex()], 'status')]"
+                  },
+                  "timeout": {
+                    "value": "[tryGet(coalesce(parameters('tasks'), createArray())[copyIndex()], 'timeout')]"
+                  },
+                  "agentConfiguration": {
+                    "value": "[tryGet(coalesce(parameters('tasks'), createArray())[copyIndex()], 'agentConfiguration')]"
+                  },
+                  "agentPoolName": {
+                    "value": "[tryGet(coalesce(parameters('tasks'), createArray())[copyIndex()], 'agentPoolName')]"
+                  },
+                  "credentials": {
+                    "value": "[tryGet(coalesce(parameters('tasks'), createArray())[copyIndex()], 'credentials')]"
+                  },
+                  "isSystemTask": {
+                    "value": "[tryGet(coalesce(parameters('tasks'), createArray())[copyIndex()], 'isSystemTask')]"
+                  },
+                  "logTemplate": {
+                    "value": "[tryGet(coalesce(parameters('tasks'), createArray())[copyIndex()], 'logTemplate')]"
+                  },
+                  "managedIdentities": {
+                    "value": "[tryGet(coalesce(parameters('tasks'), createArray())[copyIndex()], 'managedIdentities')]"
+                  },
+                  "enableTelemetry": {
+                    "value": "[variables('enableReferencedModulesTelemetry')]"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "languageVersion": "2.0",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.42.1.51946",
+                      "templateHash": "2468771835002458415"
+                    },
+                    "name": "Container Registries Tasks",
+                    "description": "Deploys an Azure Container Registry (ACR) Task that can be used to automate container image builds and other workflows ([ref](https://learn.microsoft.com/en-us/azure/container-registry/container-registry-tasks-overview))."
+                  },
+                  "definitions": {
+                    "managedIdentityAllType": {
+                      "type": "object",
+                      "properties": {
+                        "systemAssigned": {
+                          "type": "bool",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Enables system assigned managed identity on the resource."
+                          }
+                        },
+                        "userAssignedResourceIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The resource ID(s) to assign to the resource. Required if a user assigned identity is used for encryption."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "description": "An AVM-aligned type for a managed identity configuration. To be used if both a system-assigned & user-assigned identities are supported by the resource provider.",
+                        "__bicep_imported_from!": {
+                          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
+                        }
+                      }
+                    }
+                  },
+                  "parameters": {
+                    "registryName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Conditional. The name of the parent registry. Required if the template is used in a standalone deployment."
+                      }
+                    },
+                    "name": {
+                      "type": "string",
+                      "minLength": 5,
+                      "maxLength": 50,
+                      "metadata": {
+                        "description": "Required. The name of the task."
+                      }
+                    },
+                    "location": {
+                      "type": "string",
+                      "defaultValue": "[resourceGroup().location]",
+                      "metadata": {
+                        "description": "Optional. Location for all resources."
+                      }
+                    },
+                    "tags": {
+                      "type": "object",
+                      "metadata": {
+                        "__bicep_resource_derived_type!": {
+                          "source": "Microsoft.ContainerRegistry/registries/tasks@2025-03-01-preview#properties/tags"
+                        },
+                        "description": "Optional. Tags of the resource."
+                      },
+                      "nullable": true
+                    },
+                    "platform": {
+                      "type": "object",
+                      "metadata": {
+                        "__bicep_resource_derived_type!": {
+                          "source": "Microsoft.ContainerRegistry/registries/tasks@2025-03-01-preview#properties/properties/properties/platform"
+                        },
+                        "description": "Optional. The platform properties against which the task has to run."
+                      },
+                      "nullable": true
+                    },
+                    "step": {
+                      "type": "object",
+                      "metadata": {
+                        "__bicep_resource_derived_type!": {
+                          "source": "Microsoft.ContainerRegistry/registries/tasks@2025-03-01-preview#properties/properties/properties/step"
+                        },
+                        "description": "Optional. The task step properties. Exactly one of dockerBuildStep, encodedTaskStep, or fileTaskStep must be provided."
+                      },
+                      "nullable": true
+                    },
+                    "trigger": {
+                      "type": "object",
+                      "metadata": {
+                        "__bicep_resource_derived_type!": {
+                          "source": "Microsoft.ContainerRegistry/registries/tasks@2025-03-01-preview#properties/properties/properties/trigger"
+                        },
+                        "description": "Optional. The properties that describe all triggers for the task."
+                      },
+                      "nullable": true
+                    },
+                    "status": {
+                      "type": "string",
+                      "defaultValue": "Enabled",
+                      "allowedValues": [
+                        "Disabled",
+                        "Enabled"
+                      ],
+                      "metadata": {
+                        "description": "Optional. The current status of task."
+                      }
+                    },
+                    "timeout": {
+                      "type": "int",
+                      "defaultValue": 3600,
+                      "minValue": 300,
+                      "maxValue": 28800,
+                      "metadata": {
+                        "description": "Optional. Run timeout in seconds."
+                      }
+                    },
+                    "agentConfiguration": {
+                      "type": "object",
+                      "metadata": {
+                        "__bicep_resource_derived_type!": {
+                          "source": "Microsoft.ContainerRegistry/registries/tasks@2025-03-01-preview#properties/properties/properties/agentConfiguration"
+                        },
+                        "description": "Optional. The machine configuration of the run agent."
+                      },
+                      "nullable": true
+                    },
+                    "agentPoolName": {
+                      "type": "string",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. The dedicated agent pool for the task."
+                      }
+                    },
+                    "credentials": {
+                      "type": "object",
+                      "metadata": {
+                        "__bicep_resource_derived_type!": {
+                          "source": "Microsoft.ContainerRegistry/registries/tasks@2025-03-01-preview#properties/properties/properties/credentials"
+                        },
+                        "description": "Optional. The properties that describe the credentials that will be used when the task is invoked."
+                      },
+                      "nullable": true
+                    },
+                    "isSystemTask": {
+                      "type": "bool",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. The value of this property indicates whether the task resource is system task or not."
+                      }
+                    },
+                    "logTemplate": {
+                      "type": "string",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. The template that describes the repository and tag information for run log artifact."
+                      }
+                    },
+                    "managedIdentities": {
+                      "$ref": "#/definitions/managedIdentityAllType",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. The managed identity definition for this resource."
+                      }
+                    },
+                    "enableTelemetry": {
+                      "type": "bool",
+                      "defaultValue": true,
+                      "metadata": {
+                        "description": "Optional. Enable/Disable usage telemetry for module."
+                      }
+                    }
+                  },
+                  "variables": {
+                    "formattedUserAssignedIdentities": "[reduce(map(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createArray()), lambda('id', createObject(format('{0}', lambdaVariables('id')), createObject()))), createObject(), lambda('cur', 'next', union(lambdaVariables('cur'), lambdaVariables('next'))))]",
+                    "identity": "[if(not(empty(parameters('managedIdentities'))), createObject('type', if(coalesce(tryGet(parameters('managedIdentities'), 'systemAssigned'), false()), if(not(empty(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createObject()))), 'SystemAssigned, UserAssigned', 'SystemAssigned'), if(not(empty(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createObject()))), 'UserAssigned', 'None')), 'userAssignedIdentities', if(not(empty(variables('formattedUserAssignedIdentities'))), variables('formattedUserAssignedIdentities'), null())), null())]"
+                  },
+                  "resources": {
+                    "avmTelemetry": {
+                      "condition": "[parameters('enableTelemetry')]",
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2025-04-01",
+                      "name": "[format('46d3xbcp.res.containerregistry-registry-task.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
+                      "properties": {
+                        "mode": "Incremental",
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                          "contentVersion": "1.0.0.0",
+                          "resources": [],
+                          "outputs": {
+                            "telemetry": {
+                              "type": "String",
+                              "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "registry": {
+                      "existing": true,
+                      "type": "Microsoft.ContainerRegistry/registries",
+                      "apiVersion": "2025-11-01",
+                      "name": "[parameters('registryName')]"
+                    },
+                    "task": {
+                      "type": "Microsoft.ContainerRegistry/registries/tasks",
+                      "apiVersion": "2025-03-01-preview",
+                      "name": "[format('{0}/{1}', parameters('registryName'), parameters('name'))]",
+                      "location": "[parameters('location')]",
+                      "identity": "[variables('identity')]",
+                      "tags": "[parameters('tags')]",
+                      "properties": {
+                        "agentConfiguration": "[parameters('agentConfiguration')]",
+                        "agentPoolName": "[parameters('agentPoolName')]",
+                        "credentials": "[parameters('credentials')]",
+                        "isSystemTask": "[parameters('isSystemTask')]",
+                        "logTemplate": "[parameters('logTemplate')]",
+                        "platform": "[parameters('platform')]",
+                        "status": "[parameters('status')]",
+                        "step": "[parameters('step')]",
+                        "timeout": "[parameters('timeout')]",
+                        "trigger": "[parameters('trigger')]"
+                      }
+                    }
+                  },
+                  "outputs": {
+                    "name": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The name of the task."
+                      },
+                      "value": "[parameters('name')]"
+                    },
+                    "resourceGroupName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The name of the resource group the task was deployed into."
+                      },
+                      "value": "[resourceGroup().name]"
+                    },
+                    "resourceId": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The resource ID of the task."
+                      },
+                      "value": "[resourceId('Microsoft.ContainerRegistry/registries/tasks', parameters('registryName'), parameters('name'))]"
+                    },
+                    "location": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The location the resource was deployed into."
+                      },
+                      "value": "[reference('task', '2025-03-01-preview', 'full').location]"
+                    },
+                    "systemAssignedMIPrincipalId": {
+                      "type": "string",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "The principal ID of the system assigned identity."
+                      },
+                      "value": "[tryGet(tryGet(reference('task', '2025-03-01-preview', 'full'), 'identity'), 'principalId')]"
+                    }
+                  }
+                }
+              },
+              "dependsOn": [
+                "registry"
+              ]
+            },
+            "registry_webhooks": {
+              "copy": {
+                "name": "registry_webhooks",
+                "count": "[length(coalesce(parameters('webhooks'), createArray()))]"
+              },
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2025-04-01",
+              "name": "[format('{0}-Registry-Webhook-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "name": {
+                    "value": "[coalesce(parameters('webhooks'), createArray())[copyIndex()].name]"
+                  },
+                  "registryName": {
+                    "value": "[parameters('name')]"
+                  },
+                  "location": {
+                    "value": "[coalesce(tryGet(coalesce(parameters('webhooks'), createArray())[copyIndex()], 'location'), parameters('location'))]"
+                  },
+                  "action": {
+                    "value": "[tryGet(coalesce(parameters('webhooks'), createArray())[copyIndex()], 'action')]"
+                  },
+                  "customHeaders": {
+                    "value": "[tryGet(coalesce(parameters('webhooks'), createArray())[copyIndex()], 'customHeaders')]"
+                  },
+                  "scope": {
+                    "value": "[tryGet(coalesce(parameters('webhooks'), createArray())[copyIndex()], 'scope')]"
+                  },
+                  "status": {
+                    "value": "[tryGet(coalesce(parameters('webhooks'), createArray())[copyIndex()], 'status')]"
+                  },
+                  "serviceUri": {
+                    "value": "[coalesce(parameters('webhooks'), createArray())[copyIndex()].serviceUri]"
+                  },
+                  "tags": {
+                    "value": "[coalesce(tryGet(coalesce(parameters('webhooks'), createArray())[copyIndex()], 'tags'), parameters('tags'))]"
+                  },
+                  "enableTelemetry": {
+                    "value": "[variables('enableReferencedModulesTelemetry')]"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "languageVersion": "2.0",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.42.1.51946",
+                      "templateHash": "3200175097987099858"
+                    },
+                    "name": "Azure Container Registry (ACR) Webhooks",
+                    "description": "This module deploys an Azure Container Registry (ACR) Webhook."
+                  },
+                  "parameters": {
+                    "registryName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Conditional. The name of the parent registry. Required if the template is used in a standalone deployment."
+                      }
+                    },
+                    "name": {
+                      "type": "string",
+                      "defaultValue": "[format('{0}webhook', parameters('registryName'))]",
+                      "minLength": 5,
+                      "maxLength": 50,
+                      "metadata": {
+                        "description": "Optional. The name of the registry webhook."
+                      }
+                    },
+                    "serviceUri": {
+                      "type": "securestring",
+                      "metadata": {
+                        "description": "Required. The service URI for the webhook to post notifications."
+                      }
+                    },
+                    "status": {
+                      "type": "string",
+                      "defaultValue": "enabled",
+                      "allowedValues": [
+                        "disabled",
+                        "enabled"
+                      ],
+                      "metadata": {
+                        "description": "Optional. The status of the webhook at the time the operation was called."
+                      }
+                    },
+                    "action": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "defaultValue": [
+                        "chart_delete",
+                        "chart_push",
+                        "delete",
+                        "push",
+                        "quarantine"
+                      ],
+                      "metadata": {
+                        "description": "Optional. The list of actions that trigger the webhook to post notifications."
+                      }
+                    },
+                    "location": {
+                      "type": "string",
+                      "defaultValue": "[resourceGroup().location]",
+                      "metadata": {
+                        "description": "Optional. Location for all resources."
+                      }
+                    },
+                    "tags": {
+                      "type": "object",
+                      "metadata": {
+                        "__bicep_resource_derived_type!": {
+                          "source": "Microsoft.ContainerRegistry/registries/webhooks@2025-11-01#properties/tags"
+                        },
+                        "description": "Optional. Tags of the resource."
+                      },
+                      "nullable": true
+                    },
+                    "customHeaders": {
+                      "type": "object",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Custom headers that will be added to the webhook notifications."
+                      }
+                    },
+                    "scope": {
+                      "type": "string",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. The scope of repositories where the event can be triggered. For example, 'foo:*' means events for all tags under repository 'foo'. 'foo:bar' means events for 'foo:bar' only. 'foo' is equivalent to 'foo:latest'. Empty means all events."
+                      }
+                    },
+                    "enableTelemetry": {
+                      "type": "bool",
+                      "defaultValue": true,
+                      "metadata": {
+                        "description": "Optional. Enable/Disable usage telemetry for module."
+                      }
+                    }
+                  },
+                  "resources": {
+                    "avmTelemetry": {
+                      "condition": "[parameters('enableTelemetry')]",
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2025-04-01",
+                      "name": "[format('46d3xbcp.res.containerregistry-registry-webhook.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
+                      "properties": {
+                        "mode": "Incremental",
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                          "contentVersion": "1.0.0.0",
+                          "resources": [],
+                          "outputs": {
+                            "telemetry": {
+                              "type": "String",
+                              "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "registry": {
+                      "existing": true,
+                      "type": "Microsoft.ContainerRegistry/registries",
+                      "apiVersion": "2025-11-01",
+                      "name": "[parameters('registryName')]"
+                    },
+                    "webhook": {
+                      "type": "Microsoft.ContainerRegistry/registries/webhooks",
+                      "apiVersion": "2025-11-01",
+                      "name": "[format('{0}/{1}', parameters('registryName'), parameters('name'))]",
+                      "location": "[parameters('location')]",
+                      "tags": "[parameters('tags')]",
+                      "properties": {
+                        "actions": "[parameters('action')]",
+                        "customHeaders": "[parameters('customHeaders')]",
+                        "scope": "[parameters('scope')]",
+                        "serviceUri": "[parameters('serviceUri')]",
+                        "status": "[parameters('status')]"
+                      }
+                    }
+                  },
+                  "outputs": {
+                    "resourceId": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The resource ID of the webhook."
+                      },
+                      "value": "[resourceId('Microsoft.ContainerRegistry/registries/webhooks', parameters('registryName'), parameters('name'))]"
+                    },
+                    "name": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The name of the webhook."
+                      },
+                      "value": "[parameters('name')]"
+                    },
+                    "resourceGroupName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The name of the Azure container registry."
+                      },
+                      "value": "[resourceGroup().name]"
+                    },
+                    "actions": {
+                      "type": "array",
+                      "metadata": {
+                        "description": "The actions of the webhook."
+                      },
+                      "value": "[reference('webhook').actions]"
+                    },
+                    "status": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The status of the webhook."
+                      },
+                      "value": "[reference('webhook').status]"
+                    },
+                    "provistioningState": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The provisioning state of the webhook."
+                      },
+                      "value": "[reference('webhook').provisioningState]"
+                    },
+                    "location": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The location the resource was deployed into."
+                      },
+                      "value": "[reference('webhook', '2025-11-01', 'full').location]"
+                    }
+                  }
+                }
+              },
+              "dependsOn": [
+                "registry"
+              ]
+            },
+            "registry_privateEndpoints": {
+              "copy": {
+                "name": "registry_privateEndpoints",
+                "count": "[length(coalesce(parameters('privateEndpoints'), createArray()))]"
+              },
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2025-04-01",
+              "name": "[format('{0}-registry-PrivateEndpoint-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+              "subscriptionId": "[split(coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'resourceGroupResourceId'), resourceGroup().id), '/')[2]]",
+              "resourceGroup": "[split(coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'resourceGroupResourceId'), resourceGroup().id), '/')[4]]",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "name": {
+                    "value": "[coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'name'), format('pep-{0}-{1}-{2}', last(split(resourceId('Microsoft.ContainerRegistry/registries', parameters('name')), '/')), coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'service'), 'registry'), copyIndex()))]"
+                  },
+                  "privateLinkServiceConnections": "[if(not(equals(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'isManualConnection'), true())), createObject('value', createArray(createObject('name', coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'privateLinkServiceConnectionName'), format('{0}-{1}-{2}', last(split(resourceId('Microsoft.ContainerRegistry/registries', parameters('name')), '/')), coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'service'), 'registry'), copyIndex())), 'properties', createObject('privateLinkServiceId', resourceId('Microsoft.ContainerRegistry/registries', parameters('name')), 'groupIds', createArray(coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'service'), 'registry')))))), createObject('value', null()))]",
+                  "manualPrivateLinkServiceConnections": "[if(equals(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'isManualConnection'), true()), createObject('value', createArray(createObject('name', coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'privateLinkServiceConnectionName'), format('{0}-{1}-{2}', last(split(resourceId('Microsoft.ContainerRegistry/registries', parameters('name')), '/')), coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'service'), 'registry'), copyIndex())), 'properties', createObject('privateLinkServiceId', resourceId('Microsoft.ContainerRegistry/registries', parameters('name')), 'groupIds', createArray(coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'service'), 'registry')), 'requestMessage', coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'manualConnectionRequestMessage'), 'Manual approval required.'))))), createObject('value', null()))]",
+                  "subnetResourceId": {
+                    "value": "[coalesce(parameters('privateEndpoints'), createArray())[copyIndex()].subnetResourceId]"
+                  },
+                  "enableTelemetry": {
+                    "value": "[variables('enableReferencedModulesTelemetry')]"
+                  },
+                  "location": {
+                    "value": "[coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'location'), reference(split(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()].subnetResourceId, '/subnets/')[0], '2020-06-01', 'Full').location)]"
+                  },
+                  "lock": {
+                    "value": "[coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'lock'), parameters('lock'))]"
+                  },
+                  "privateDnsZoneGroup": {
+                    "value": "[tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'privateDnsZoneGroup')]"
+                  },
+                  "roleAssignments": {
+                    "value": "[tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'roleAssignments')]"
+                  },
+                  "tags": {
+                    "value": "[coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'tags'), parameters('tags'))]"
+                  },
+                  "customDnsConfigs": {
+                    "value": "[tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'customDnsConfigs')]"
+                  },
+                  "ipConfigurations": {
+                    "value": "[tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'ipConfigurations')]"
+                  },
+                  "applicationSecurityGroupResourceIds": {
+                    "value": "[tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'applicationSecurityGroupResourceIds')]"
+                  },
+                  "customNetworkInterfaceName": {
+                    "value": "[tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'customNetworkInterfaceName')]"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "languageVersion": "2.0",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.41.2.15936",
+                      "templateHash": "18436885663402767850"
+                    },
+                    "name": "Private Endpoints",
+                    "description": "This module deploys a Private Endpoint."
+                  },
+                  "definitions": {
+                    "privateDnsZoneGroupType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The name of the Private DNS Zone Group."
+                          }
+                        },
+                        "privateDnsZoneGroupConfigs": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/definitions/privateDnsZoneGroupConfigType"
+                          },
+                          "metadata": {
+                            "description": "Required. The private DNS zone groups to associate the private endpoint. A DNS zone group can support up to 5 DNS zones."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "__bicep_export!": true,
+                        "description": "The type of a private dns zone group."
+                      }
+                    },
+                    "lockType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Specify the name of lock."
+                          }
+                        },
+                        "kind": {
+                          "type": "string",
+                          "allowedValues": [
+                            "CanNotDelete",
+                            "None",
+                            "ReadOnly"
+                          ],
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Specify the type of lock."
+                          }
+                        },
+                        "notes": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Specify the notes of the lock."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "description": "An AVM-aligned type for a lock.",
+                        "__bicep_imported_from!": {
+                          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
+                        }
+                      }
+                    },
+                    "privateDnsZoneGroupConfigType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The name of the private DNS zone group config."
+                          }
+                        },
+                        "privateDnsZoneResourceId": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The resource id of the private DNS zone."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "description": "The type of a private DNS zone group configuration.",
+                        "__bicep_imported_from!": {
+                          "sourceTemplate": "private-dns-zone-group/main.bicep"
+                        }
+                      }
+                    },
+                    "roleAssignmentType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The name (as GUID) of the role assignment. If not provided, a GUID will be generated."
+                          }
+                        },
+                        "roleDefinitionIdOrName": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The role to assign. You can provide either the display name of the role definition, the role definition GUID, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'."
+                          }
+                        },
+                        "principalId": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The principal ID of the principal (user/group/identity) to assign the role to."
+                          }
+                        },
+                        "principalType": {
+                          "type": "string",
+                          "allowedValues": [
+                            "Device",
+                            "ForeignGroup",
+                            "Group",
+                            "ServicePrincipal",
+                            "User"
+                          ],
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The principal type of the assigned principal ID."
+                          }
+                        },
+                        "description": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The description of the role assignment."
+                          }
+                        },
+                        "condition": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase \"foo_storage_container\"."
+                          }
+                        },
+                        "conditionVersion": {
+                          "type": "string",
+                          "allowedValues": [
+                            "2.0"
+                          ],
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Version of the condition."
+                          }
+                        },
+                        "delegatedManagedIdentityResourceId": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The Resource Id of the delegated managed identity resource."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "description": "An AVM-aligned type for a role assignment.",
+                        "__bicep_imported_from!": {
+                          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
+                        }
+                      }
+                    }
+                  },
+                  "parameters": {
+                    "name": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. Name of the private endpoint resource to create."
+                      }
+                    },
+                    "subnetResourceId": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. Resource ID of the subnet where the endpoint needs to be created."
+                      }
+                    },
+                    "applicationSecurityGroupResourceIds": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Application security groups in which the private endpoint IP configuration is included."
+                      }
+                    },
+                    "customNetworkInterfaceName": {
+                      "type": "string",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. The custom name of the network interface attached to the private endpoint."
+                      }
+                    },
+                    "ipConfigurations": {
+                      "type": "array",
+                      "metadata": {
+                        "__bicep_resource_derived_type!": {
+                          "source": "Microsoft.Network/privateEndpoints@2025-05-01#properties/properties/properties/ipConfigurations"
+                        },
+                        "description": "Optional. A list of IP configurations of the private endpoint. This will be used to map to the First Party Service endpoints."
+                      },
+                      "nullable": true
+                    },
+                    "ipVersionType": {
+                      "type": "string",
+                      "metadata": {
+                        "__bicep_resource_derived_type!": {
+                          "source": "Microsoft.Network/privateEndpoints@2025-05-01#properties/properties/properties/ipVersionType"
+                        },
+                        "description": "Optional. Specifies the IP version type for the private IPs of the private endpoint. If not defined, this defaults to IPv4."
+                      },
+                      "defaultValue": "IPv4"
+                    },
+                    "privateDnsZoneGroup": {
+                      "$ref": "#/definitions/privateDnsZoneGroupType",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. The private DNS zone group to configure for the private endpoint."
+                      }
+                    },
+                    "location": {
+                      "type": "string",
+                      "defaultValue": "[resourceGroup().location]",
+                      "metadata": {
+                        "description": "Optional. Location for all Resources."
+                      }
+                    },
+                    "lock": {
+                      "$ref": "#/definitions/lockType",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. The lock settings of the service."
+                      }
+                    },
+                    "roleAssignments": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/roleAssignmentType"
+                      },
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Array of role assignments to create."
+                      }
+                    },
+                    "tags": {
+                      "type": "object",
+                      "metadata": {
+                        "__bicep_resource_derived_type!": {
+                          "source": "Microsoft.Network/privateEndpoints@2025-05-01#properties/tags"
+                        },
+                        "description": "Optional. Tags to be applied on all resources/resource groups in this deployment."
+                      },
+                      "nullable": true
+                    },
+                    "customDnsConfigs": {
+                      "type": "array",
+                      "metadata": {
+                        "__bicep_resource_derived_type!": {
+                          "source": "Microsoft.Network/privateEndpoints@2025-05-01#properties/properties/properties/customDnsConfigs"
+                        },
+                        "description": "Optional. Custom DNS configurations."
+                      },
+                      "nullable": true
+                    },
+                    "manualPrivateLinkServiceConnections": {
+                      "type": "array",
+                      "metadata": {
+                        "__bicep_resource_derived_type!": {
+                          "source": "Microsoft.Network/privateEndpoints@2025-05-01#properties/properties/properties/manualPrivateLinkServiceConnections"
+                        },
+                        "description": "Conditional. A grouping of information about the connection to the remote resource. Used when the network admin does not have access to approve connections to the remote resource. Required if `privateLinkServiceConnections` is empty."
+                      },
+                      "nullable": true
+                    },
+                    "privateLinkServiceConnections": {
+                      "type": "array",
+                      "metadata": {
+                        "__bicep_resource_derived_type!": {
+                          "source": "Microsoft.Network/privateEndpoints@2025-05-01#properties/properties/properties/privateLinkServiceConnections"
+                        },
+                        "description": "Conditional. A grouping of information about the connection to the remote resource. Required if `manualPrivateLinkServiceConnections` is empty."
+                      },
+                      "nullable": true
+                    },
+                    "enableTelemetry": {
+                      "type": "bool",
+                      "defaultValue": true,
+                      "metadata": {
+                        "description": "Optional. Enable/Disable usage telemetry for module."
+                      }
+                    }
+                  },
+                  "variables": {
+                    "copy": [
+                      {
+                        "name": "formattedRoleAssignments",
+                        "count": "[length(coalesce(parameters('roleAssignments'), createArray()))]",
+                        "input": "[union(coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')], createObject('roleDefinitionId', coalesce(tryGet(variables('builtInRoleNames'), coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName), if(contains(coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName, '/providers/Microsoft.Authorization/roleDefinitions/'), coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName)))))]"
+                      }
+                    ],
+                    "builtInRoleNames": {
+                      "Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
+                      "DNS Resolver Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '0f2ebee7-ffd4-4fc0-b3b7-664099fdad5d')]",
+                      "DNS Zone Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'befefa01-2a29-4197-83a8-272ff33ce314')]",
+                      "Domain Services Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'eeaeda52-9324-47f6-8069-5d5bade478b2')]",
+                      "Domain Services Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '361898ef-9ed1-48c2-849c-a832951106bb')]",
+                      "Network Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4d97b98b-1d4f-4787-a291-c67834d212e7')]",
+                      "Owner": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')]",
+                      "Private DNS Zone Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b12aa53e-6015-4669-85d0-8515ebb3ae7f')]",
+                      "Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')]",
+                      "Role Based Access Control Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f58310d9-a9f6-439a-9e8d-f62e7b41a168')]"
+                    }
+                  },
+                  "resources": {
+                    "avmTelemetry": {
+                      "condition": "[parameters('enableTelemetry')]",
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2025-04-01",
+                      "name": "[format('46d3xbcp.res.network-privateendpoint.{0}.{1}', replace('0.12.0', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
+                      "properties": {
+                        "mode": "Incremental",
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                          "contentVersion": "1.0.0.0",
+                          "resources": [],
+                          "outputs": {
+                            "telemetry": {
+                              "type": "String",
+                              "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "privateEndpoint": {
+                      "type": "Microsoft.Network/privateEndpoints",
+                      "apiVersion": "2025-05-01",
+                      "name": "[parameters('name')]",
+                      "location": "[parameters('location')]",
+                      "tags": "[parameters('tags')]",
+                      "properties": {
+                        "copy": [
+                          {
+                            "name": "applicationSecurityGroups",
+                            "count": "[length(coalesce(parameters('applicationSecurityGroupResourceIds'), createArray()))]",
+                            "input": {
+                              "id": "[coalesce(parameters('applicationSecurityGroupResourceIds'), createArray())[copyIndex('applicationSecurityGroups')]]"
+                            }
+                          }
+                        ],
+                        "customDnsConfigs": "[coalesce(parameters('customDnsConfigs'), createArray())]",
+                        "customNetworkInterfaceName": "[coalesce(parameters('customNetworkInterfaceName'), '')]",
+                        "ipConfigurations": "[coalesce(parameters('ipConfigurations'), createArray())]",
+                        "manualPrivateLinkServiceConnections": "[coalesce(parameters('manualPrivateLinkServiceConnections'), createArray())]",
+                        "privateLinkServiceConnections": "[coalesce(parameters('privateLinkServiceConnections'), createArray())]",
+                        "subnet": {
+                          "id": "[parameters('subnetResourceId')]"
+                        },
+                        "ipVersionType": "[parameters('ipVersionType')]"
+                      }
+                    },
+                    "privateEndpoint_lock": {
+                      "condition": "[and(not(empty(coalesce(parameters('lock'), createObject()))), not(equals(tryGet(parameters('lock'), 'kind'), 'None')))]",
+                      "type": "Microsoft.Authorization/locks",
+                      "apiVersion": "2020-05-01",
+                      "scope": "[resourceId('Microsoft.Network/privateEndpoints', parameters('name'))]",
+                      "name": "[coalesce(tryGet(parameters('lock'), 'name'), format('lock-{0}', parameters('name')))]",
+                      "properties": {
+                        "level": "[coalesce(tryGet(parameters('lock'), 'kind'), '')]",
+                        "notes": "[coalesce(tryGet(parameters('lock'), 'notes'), if(equals(tryGet(parameters('lock'), 'kind'), 'CanNotDelete'), 'Cannot delete resource or child resources.', 'Cannot delete or modify the resource or child resources.'))]"
+                      },
+                      "dependsOn": [
+                        "privateEndpoint"
+                      ]
+                    },
+                    "privateEndpoint_roleAssignments": {
+                      "copy": {
+                        "name": "privateEndpoint_roleAssignments",
+                        "count": "[length(coalesce(variables('formattedRoleAssignments'), createArray()))]"
+                      },
+                      "type": "Microsoft.Authorization/roleAssignments",
+                      "apiVersion": "2022-04-01",
+                      "scope": "[resourceId('Microsoft.Network/privateEndpoints', parameters('name'))]",
+                      "name": "[coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'name'), guid(resourceId('Microsoft.Network/privateEndpoints', parameters('name')), coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId, coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId))]",
+                      "properties": {
+                        "roleDefinitionId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId]",
+                        "principalId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId]",
+                        "description": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'description')]",
+                        "principalType": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'principalType')]",
+                        "condition": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'condition')]",
+                        "conditionVersion": "[if(not(empty(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'condition'))), coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'conditionVersion'), '2.0'), null())]",
+                        "delegatedManagedIdentityResourceId": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'delegatedManagedIdentityResourceId')]"
+                      },
+                      "dependsOn": [
+                        "privateEndpoint"
+                      ]
+                    },
+                    "privateEndpoint_privateDnsZoneGroup": {
+                      "condition": "[not(empty(parameters('privateDnsZoneGroup')))]",
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2025-04-01",
+                      "name": "[format('{0}-PrivateEndpoint-PrivateDnsZoneGroup', uniqueString(deployment().name))]",
+                      "properties": {
+                        "expressionEvaluationOptions": {
+                          "scope": "inner"
+                        },
+                        "mode": "Incremental",
+                        "parameters": {
+                          "name": {
+                            "value": "[tryGet(parameters('privateDnsZoneGroup'), 'name')]"
+                          },
+                          "privateEndpointName": {
+                            "value": "[parameters('name')]"
+                          },
+                          "privateDnsZoneConfigs": {
+                            "value": "[parameters('privateDnsZoneGroup').privateDnsZoneGroupConfigs]"
+                          }
+                        },
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                          "languageVersion": "2.0",
+                          "contentVersion": "1.0.0.0",
+                          "metadata": {
+                            "_generator": {
+                              "name": "bicep",
+                              "version": "0.41.2.15936",
+                              "templateHash": "9935179114830442414"
+                            },
+                            "name": "Private Endpoint Private DNS Zone Groups",
+                            "description": "This module deploys a Private Endpoint Private DNS Zone Group."
+                          },
+                          "definitions": {
+                            "privateDnsZoneGroupConfigType": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The name of the private DNS zone group config."
+                                  }
+                                },
+                                "privateDnsZoneResourceId": {
+                                  "type": "string",
+                                  "metadata": {
+                                    "description": "Required. The resource id of the private DNS zone."
+                                  }
+                                }
+                              },
+                              "metadata": {
+                                "__bicep_export!": true,
+                                "description": "The type of a private DNS zone group configuration."
+                              }
+                            }
+                          },
+                          "parameters": {
+                            "privateEndpointName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Conditional. The name of the parent private endpoint. Required if the template is used in a standalone deployment."
+                              }
+                            },
+                            "privateDnsZoneConfigs": {
+                              "type": "array",
+                              "items": {
+                                "$ref": "#/definitions/privateDnsZoneGroupConfigType"
+                              },
+                              "minLength": 1,
+                              "maxLength": 5,
+                              "metadata": {
+                                "description": "Required. Array of private DNS zone configurations of the private DNS zone group. A DNS zone group can support up to 5 DNS zones."
+                              }
+                            },
+                            "name": {
+                              "type": "string",
+                              "defaultValue": "default",
+                              "metadata": {
+                                "description": "Optional. The name of the private DNS zone group."
+                              }
+                            }
+                          },
+                          "resources": {
+                            "privateEndpoint": {
+                              "existing": true,
+                              "type": "Microsoft.Network/privateEndpoints",
+                              "apiVersion": "2025-05-01",
+                              "name": "[parameters('privateEndpointName')]"
+                            },
+                            "privateDnsZoneGroup": {
+                              "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
+                              "apiVersion": "2025-05-01",
+                              "name": "[format('{0}/{1}', parameters('privateEndpointName'), parameters('name'))]",
+                              "properties": {
+                                "copy": [
+                                  {
+                                    "name": "privateDnsZoneConfigs",
+                                    "count": "[length(parameters('privateDnsZoneConfigs'))]",
+                                    "input": {
+                                      "name": "[coalesce(tryGet(parameters('privateDnsZoneConfigs')[copyIndex('privateDnsZoneConfigs')], 'name'), last(split(parameters('privateDnsZoneConfigs')[copyIndex('privateDnsZoneConfigs')].privateDnsZoneResourceId, '/')))]",
+                                      "properties": {
+                                        "privateDnsZoneId": "[parameters('privateDnsZoneConfigs')[copyIndex('privateDnsZoneConfigs')].privateDnsZoneResourceId]"
+                                      }
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          },
+                          "outputs": {
+                            "name": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The name of the private endpoint DNS zone group."
+                              },
+                              "value": "[parameters('name')]"
+                            },
+                            "resourceId": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The resource ID of the private endpoint DNS zone group."
+                              },
+                              "value": "[resourceId('Microsoft.Network/privateEndpoints/privateDnsZoneGroups', parameters('privateEndpointName'), parameters('name'))]"
+                            },
+                            "resourceGroupName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The resource group the private endpoint DNS zone group was deployed into."
+                              },
+                              "value": "[resourceGroup().name]"
+                            }
+                          }
+                        }
+                      },
+                      "dependsOn": [
+                        "privateEndpoint"
+                      ]
+                    }
+                  },
+                  "outputs": {
+                    "resourceGroupName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The resource group the private endpoint was deployed into."
+                      },
+                      "value": "[resourceGroup().name]"
+                    },
+                    "resourceId": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The resource ID of the private endpoint."
+                      },
+                      "value": "[resourceId('Microsoft.Network/privateEndpoints', parameters('name'))]"
+                    },
+                    "name": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The name of the private endpoint."
+                      },
+                      "value": "[parameters('name')]"
+                    },
+                    "location": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The location the resource was deployed into."
+                      },
+                      "value": "[reference('privateEndpoint', '2025-05-01', 'full').location]"
+                    },
+                    "customDnsConfigs": {
+                      "type": "array",
+                      "metadata": {
+                        "__bicep_resource_derived_type!": {
+                          "source": "Microsoft.Network/privateEndpoints@2025-05-01#properties/properties/properties/customDnsConfigs",
+                          "output": true
+                        },
+                        "description": "The custom DNS configurations of the private endpoint."
+                      },
+                      "value": "[reference('privateEndpoint').customDnsConfigs]"
+                    },
+                    "networkInterfaceResourceIds": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "metadata": {
+                        "description": "The resource IDs of the network interfaces associated with the private endpoint."
+                      },
+                      "value": "[map(reference('privateEndpoint').networkInterfaces, lambda('nic', lambdaVariables('nic').id))]"
+                    },
+                    "groupId": {
+                      "type": "string",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "The group Id for the private endpoint Group."
+                      },
+                      "value": "[coalesce(tryGet(tryGet(tryGet(tryGet(reference('privateEndpoint'), 'manualPrivateLinkServiceConnections'), 0, 'properties'), 'groupIds'), 0), tryGet(tryGet(tryGet(tryGet(reference('privateEndpoint'), 'privateLinkServiceConnections'), 0, 'properties'), 'groupIds'), 0))]"
+                    }
+                  }
+                }
+              },
+              "dependsOn": [
+                "registry",
+                "registry_replications"
+              ]
+            }
+          },
+          "outputs": {
+            "name": {
+              "type": "string",
+              "metadata": {
+                "description": "The Name of the Azure container registry."
+              },
+              "value": "[parameters('name')]"
+            },
+            "loginServer": {
+              "type": "string",
+              "metadata": {
+                "description": "The reference to the Azure container registry."
+              },
+              "value": "[reference('registry').loginServer]"
+            },
+            "resourceGroupName": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the Azure container registry."
+              },
+              "value": "[resourceGroup().name]"
+            },
+            "resourceId": {
+              "type": "string",
+              "metadata": {
+                "description": "The resource ID of the Azure container registry."
+              },
+              "value": "[resourceId('Microsoft.ContainerRegistry/registries', parameters('name'))]"
+            },
+            "systemAssignedMIPrincipalId": {
+              "type": "string",
+              "nullable": true,
+              "metadata": {
+                "description": "The principal ID of the system assigned identity."
+              },
+              "value": "[tryGet(tryGet(reference('registry', '2025-06-01-preview', 'full'), 'identity'), 'principalId')]"
+            },
+            "location": {
+              "type": "string",
+              "metadata": {
+                "description": "The location the resource was deployed into."
+              },
+              "value": "[reference('registry', '2025-06-01-preview', 'full').location]"
+            },
+            "credentialSetsSystemAssignedMIPrincipalIds": {
+              "type": "array",
+              "metadata": {
+                "description": "The Principal IDs of the ACR Credential Sets system-assigned identities."
+              },
+              "copy": {
+                "count": "[length(range(0, length(coalesce(parameters('credentialSets'), createArray()))))]",
+                "input": "[tryGet(tryGet(reference(format('registry_credentialSets[{0}]', range(0, length(coalesce(parameters('credentialSets'), createArray())))[copyIndex()])).outputs, 'systemAssignedMIPrincipalId'), 'value')]"
+              }
+            },
+            "credentialSetsResourceIds": {
+              "type": "array",
+              "metadata": {
+                "description": "The Resource IDs of the ACR Credential Sets."
+              },
+              "copy": {
+                "count": "[length(range(0, length(coalesce(parameters('credentialSets'), createArray()))))]",
+                "input": "[reference(format('registry_credentialSets[{0}]', range(0, length(coalesce(parameters('credentialSets'), createArray())))[copyIndex()])).outputs.resourceId.value]"
+              }
+            },
+            "privateEndpoints": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/privateEndpointOutputType"
+              },
+              "metadata": {
+                "description": "The private endpoints of the Azure container registry."
+              },
+              "copy": {
+                "count": "[length(coalesce(parameters('privateEndpoints'), createArray()))]",
+                "input": {
+                  "name": "[reference(format('registry_privateEndpoints[{0}]', copyIndex())).outputs.name.value]",
+                  "resourceId": "[reference(format('registry_privateEndpoints[{0}]', copyIndex())).outputs.resourceId.value]",
+                  "groupId": "[tryGet(tryGet(reference(format('registry_privateEndpoints[{0}]', copyIndex())).outputs, 'groupId'), 'value')]",
+                  "customDnsConfigs": "[reference(format('registry_privateEndpoints[{0}]', copyIndex())).outputs.customDnsConfigs.value]",
+                  "networkInterfaceResourceIds": "[reference(format('registry_privateEndpoints[{0}]', copyIndex())).outputs.networkInterfaceResourceIds.value]"
+                }
+              }
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "appIdentity"
+      ]
+    },
     "containerAppsEnvironment": {
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2025-04-01",
@@ -47978,11 +51819,19 @@
               ]
             }
           },
+          "registries": {
+            "value": [
+              {
+                "server": "[reference('containerRegistry').outputs.loginServer.value]",
+                "identity": "[reference('appIdentity').outputs.resourceId.value]"
+              }
+            ]
+          },
           "containers": {
             "value": [
               {
                 "name": "cmsabackend",
-                "image": "[format('{0}/cmsabackend:{1}', parameters('containerRegistryEndpoint'), parameters('imageTag'))]",
+                "image": "[variables('placeholderContainerImage')]",
                 "env": "[concat(createArray(createObject('name', 'COSMOSDB_ENDPOINT', 'value', reference('cosmosDb').outputs.endpoint.value), createObject('name', 'COSMOSDB_DATABASE', 'value', reference('cosmosDb').outputs.databaseName.value), createObject('name', 'COSMOSDB_BATCH_CONTAINER', 'value', reference('cosmosDb').outputs.containerNames.value.batch), createObject('name', 'COSMOSDB_FILE_CONTAINER', 'value', reference('cosmosDb').outputs.containerNames.value.file), createObject('name', 'COSMOSDB_LOG_CONTAINER', 'value', reference('cosmosDb').outputs.containerNames.value.log), createObject('name', 'AZURE_BLOB_ACCOUNT_NAME', 'value', reference('storageAccount').outputs.name.value), createObject('name', 'AZURE_BLOB_CONTAINER_NAME', 'value', variables('appStorageContainerName')), createObject('name', 'MIGRATOR_AGENT_MODEL_DEPLOY', 'value', variables('modelDeployment').name), createObject('name', 'PICKER_AGENT_MODEL_DEPLOY', 'value', variables('modelDeployment').name), createObject('name', 'FIXER_AGENT_MODEL_DEPLOY', 'value', variables('modelDeployment').name), createObject('name', 'SEMANTIC_VERIFIER_AGENT_MODEL_DEPLOY', 'value', variables('modelDeployment').name), createObject('name', 'SYNTAX_CHECKER_AGENT_MODEL_DEPLOY', 'value', variables('modelDeployment').name), createObject('name', 'SELECTION_MODEL_DEPLOY', 'value', variables('modelDeployment').name), createObject('name', 'TERMINATION_MODEL_DEPLOY', 'value', variables('modelDeployment').name), createObject('name', 'AZURE_AI_AGENT_MODEL_DEPLOYMENT_NAME', 'value', variables('modelDeployment').name), createObject('name', 'AI_PROJECT_ENDPOINT', 'value', reference('aiServices').outputs.aiProjectInfo.value.apiEndpoint), createObject('name', 'AZURE_AI_AGENT_PROJECT_CONNECTION_STRING', 'value', reference('aiServices').outputs.aiProjectInfo.value.apiEndpoint), createObject('name', 'AZURE_AI_AGENT_PROJECT_NAME', 'value', reference('aiServices').outputs.aiProjectInfo.value.name), createObject('name', 'AZURE_AI_AGENT_RESOURCE_GROUP_NAME', 'value', resourceGroup().name), createObject('name', 'AZURE_AI_AGENT_SUBSCRIPTION_ID', 'value', subscription().subscriptionId), createObject('name', 'AZURE_AI_AGENT_ENDPOINT', 'value', reference('aiServices').outputs.aiProjectInfo.value.apiEndpoint), createObject('name', 'AZURE_CLIENT_ID', 'value', reference('appIdentity').outputs.clientId.value), createObject('name', 'APP_ENV', 'value', 'prod'), createObject('name', 'AZURE_BASIC_LOGGING_LEVEL', 'value', 'INFO'), createObject('name', 'AZURE_PACKAGE_LOGGING_LEVEL', 'value', 'WARNING'), createObject('name', 'AZURE_LOGGING_PACKAGES', 'value', '')), if(parameters('enableMonitoring'), createArray(createObject('name', 'APPLICATIONINSIGHTS_INSTRUMENTATION_KEY', 'value', reference('applicationInsights').outputs.instrumentationKey.value), createObject('name', 'APPLICATIONINSIGHTS_CONNECTION_STRING', 'value', reference('applicationInsights').outputs.connectionString.value)), createArray()))]",
                 "resources": {
                   "cpu": 1,
@@ -49517,6 +53366,7 @@
         "appIdentity",
         "applicationInsights",
         "containerAppsEnvironment",
+        "containerRegistry",
         "cosmosDb",
         "storageAccount"
       ]
@@ -49547,6 +53397,14 @@
               ]
             }
           },
+          "registries": {
+            "value": [
+              {
+                "server": "[reference('containerRegistry').outputs.loginServer.value]",
+                "identity": "[reference('appIdentity').outputs.resourceId.value]"
+              }
+            ]
+          },
           "containers": {
             "value": [
               {
@@ -49560,7 +53418,7 @@
                     "value": "prod"
                   }
                 ],
-                "image": "[format('{0}/cmsafrontend:{1}', parameters('containerRegistryEndpoint'), parameters('imageTag'))]",
+                "image": "[variables('placeholderContainerImage')]",
                 "name": "cmsafrontend",
                 "resources": {
                   "cpu": 1,
@@ -51092,7 +54950,8 @@
       "dependsOn": [
         "appIdentity",
         "containerAppBackend",
-        "containerAppsEnvironment"
+        "containerAppsEnvironment",
+        "containerRegistry"
       ]
     }
   },
@@ -51195,6 +55054,41 @@
     "SYNTAX_CHECKER_AGENT_MODEL_DEPLOY": {
       "type": "string",
       "value": "[variables('modelDeployment').name]"
+    },
+    "AZURE_CONTAINER_REGISTRY_ENDPOINT": {
+      "type": "string",
+      "metadata": {
+        "description": "Login server of the Azure Container Registry provisioned for this deployment."
+      },
+      "value": "[reference('containerRegistry').outputs.loginServer.value]"
+    },
+    "AZURE_CONTAINER_REGISTRY_NAME": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the Azure Container Registry provisioned for this deployment."
+      },
+      "value": "[reference('containerRegistry').outputs.name.value]"
+    },
+    "AZURE_ENV_IMAGE_TAG": {
+      "type": "string",
+      "metadata": {
+        "description": "Image tag used when building and pushing the backend/frontend images."
+      },
+      "value": "[parameters('imageTag')]"
+    },
+    "BACKEND_CONTAINER_APP_NAME": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the backend container app to update with the freshly built image."
+      },
+      "value": "[reference('containerAppBackend').outputs.name.value]"
+    },
+    "FRONTEND_CONTAINER_APP_NAME": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the frontend container app to update with the freshly built image."
+      },
+      "value": "[reference('containerAppFrontend').outputs.name.value]"
     }
   }
 }

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -23,9 +23,6 @@
     "imageTag": {
       "value": "${AZURE_ENV_IMAGE_TAG=latest}"
     },
-    "containerRegistryEndpoint": {
-      "value": "${AZURE_ENV_CONTAINER_REGISTRY_ENDPOINT=cmsacontainerreg.azurecr.io}"
-    },
     "existingLogAnalyticsWorkspaceId": {
       "value": "${AZURE_ENV_EXISTING_LOG_ANALYTICS_WORKSPACE_RID}"
     },

--- a/infra/main.waf.parameters.json
+++ b/infra/main.waf.parameters.json
@@ -23,9 +23,6 @@
     "imageTag": {
       "value": "${AZURE_ENV_IMAGE_TAG=latest}"
     },
-    "containerRegistryEndpoint": {
-      "value": "${AZURE_ENV_CONTAINER_REGISTRY_ENDPOINT=cmsacontainerreg.azurecr.io}"
-    },
     "existingLogAnalyticsWorkspaceId": {
       "value": "${AZURE_ENV_EXISTING_LOG_ANALYTICS_WORKSPACE_RID}"
     },

--- a/infra/main_custom.bicep
+++ b/infra/main_custom.bicep
@@ -98,8 +98,8 @@ param enableTelemetry bool = true
 param deploymentType string = 'GlobalStandard'
 
 @minLength(1)
-@description('Optional. Name of the GPT model to deploy. Defaults to gpt-4o.')
-param gptModelName string = 'gpt-4o'
+@description('Optional. Name of the GPT model to deploy. Defaults to gpt-5.1.')
+param gptModelName string = 'gpt-5.1'
 
 @description('Optional. Container image name for backend service. Used by azd for container deployments.')
 param backendImageName string = ''

--- a/infra/main_custom.bicep
+++ b/infra/main_custom.bicep
@@ -34,7 +34,7 @@ param location string = resourceGroup().location
   azd : {
     type: 'location'
     usageName : [
-      'OpenAI.GlobalStandard.gpt-4o, 150'
+      'OpenAI.GlobalStandard.gpt-5.1, 150'
     ]
   }
 })
@@ -111,8 +111,8 @@ param frontendImageName string = ''
 param imageTag string = 'latest'
 
 @minLength(1)
-@description('Optional. Version of the GPT model to deploy. Defaults to 2024-08-06.')
-param gptModelVersion string = '2024-08-06'
+@description('Optional. Version of the GPT model to deploy. Defaults to 2025-11-13.')
+param gptModelVersion string = '2025-11-13'
 
 @description('Optional. Use this parameter to use an existing AI project resource ID. Defaults to empty string.')
 param existingFoundryProjectResourceId string = ''

--- a/scripts/build_and_push_images.ps1
+++ b/scripts/build_and_push_images.ps1
@@ -1,0 +1,91 @@
+#Requires -Version 7.0
+$ErrorActionPreference = 'Stop'
+
+# ---------------------------------------------------------------------------
+# Post-provision hook (PowerShell)
+#
+# Builds the backend and frontend container images remotely inside the
+# deployment's Azure Container Registry (ACR) using 'az acr build' (no local
+# Docker required) and then updates the container apps to run the freshly
+# built images.
+#
+# The required values are provided by azd as environment variables (they are
+# outputs of infra/main.bicep). When the script is run outside of an azd hook
+# the values are read back with 'azd env get-value'.
+# ---------------------------------------------------------------------------
+
+Write-Host "==> Post-provision: building and pushing application images to ACR"
+
+# Ensure the Azure CLI is available and authenticated (az acr build / containerapp
+# update use the az CLI, which authenticates independently from azd).
+if (-not (Get-Command az -ErrorAction SilentlyContinue)) {
+    Write-Error "Azure CLI ('az') is not installed. Install it from https://aka.ms/azcli"
+    exit 1
+}
+az account show --output none 2>$null
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "You are not signed in to the Azure CLI. Run 'az login' and retry."
+    exit 1
+}
+
+function Get-EnvValue {
+    param([string]$Name)
+    $value = [Environment]::GetEnvironmentVariable($Name)
+    if ([string]::IsNullOrWhiteSpace($value)) {
+        $value = (azd env get-value $Name 2>$null)
+    }
+    return $value
+}
+
+$AcrName       = Get-EnvValue 'AZURE_CONTAINER_REGISTRY_NAME'
+$AcrEndpoint   = Get-EnvValue 'AZURE_CONTAINER_REGISTRY_ENDPOINT'
+$ResourceGroup = Get-EnvValue 'AZURE_RESOURCE_GROUP'
+$BackendApp    = Get-EnvValue 'BACKEND_CONTAINER_APP_NAME'
+$FrontendApp   = Get-EnvValue 'FRONTEND_CONTAINER_APP_NAME'
+$ImageTag      = Get-EnvValue 'AZURE_ENV_IMAGE_TAG'
+if ([string]::IsNullOrWhiteSpace($ImageTag)) { $ImageTag = 'latest' }
+
+# Derive the login server from the registry name if the output was not available.
+if ([string]::IsNullOrWhiteSpace($AcrEndpoint) -and -not [string]::IsNullOrWhiteSpace($AcrName)) {
+    $AcrEndpoint = "$AcrName.azurecr.io"
+}
+
+$missing = @()
+if ([string]::IsNullOrWhiteSpace($AcrName))       { $missing += 'AZURE_CONTAINER_REGISTRY_NAME' }
+if ([string]::IsNullOrWhiteSpace($ResourceGroup)) { $missing += 'AZURE_RESOURCE_GROUP' }
+if ([string]::IsNullOrWhiteSpace($BackendApp))    { $missing += 'BACKEND_CONTAINER_APP_NAME' }
+if ([string]::IsNullOrWhiteSpace($FrontendApp))   { $missing += 'FRONTEND_CONTAINER_APP_NAME' }
+if ($missing.Count -gt 0) {
+    Write-Error "Missing required environment values: $($missing -join ', ')"
+    exit 1
+}
+
+# Resolve the repository root (this script lives in <repo>/scripts).
+$RepoRoot = Split-Path -Parent $PSScriptRoot
+$BackendImage  = "cmsabackend:$ImageTag"
+$FrontendImage = "cmsafrontend:$ImageTag"
+
+# Ensure the Microsoft.App resource provider is registered before updating the
+# container apps. ARM registration can still be propagating after provisioning,
+# which makes 'az containerapp update' fail with a "not registered" error.
+Write-Host "==> Ensuring the Microsoft.App resource provider is registered"
+az provider register --namespace Microsoft.App --wait
+if ($LASTEXITCODE -ne 0) { throw "Failed to register the Microsoft.App resource provider." }
+
+Write-Host "==> Building backend image ($BackendImage) in ACR '$AcrName'"
+az acr build --registry $AcrName --image $BackendImage --file "$RepoRoot/src/backend/Dockerfile" "$RepoRoot/src/backend"
+if ($LASTEXITCODE -ne 0) { throw "Backend image build failed." }
+
+Write-Host "==> Building frontend image ($FrontendImage) in ACR '$AcrName'"
+az acr build --registry $AcrName --image $FrontendImage --file "$RepoRoot/src/frontend/Dockerfile" "$RepoRoot/src/frontend"
+if ($LASTEXITCODE -ne 0) { throw "Frontend image build failed." }
+
+Write-Host "==> Updating backend container app '$BackendApp'"
+az containerapp update --name $BackendApp --resource-group $ResourceGroup --image "$AcrEndpoint/$BackendImage" --output none
+if ($LASTEXITCODE -ne 0) { throw "Backend container app update failed." }
+
+Write-Host "==> Updating frontend container app '$FrontendApp'"
+az containerapp update --name $FrontendApp --resource-group $ResourceGroup --image "$AcrEndpoint/$FrontendImage" --output none
+if ($LASTEXITCODE -ne 0) { throw "Frontend container app update failed." }
+
+Write-Host "==> Done. Container apps are now running the freshly built images."

--- a/scripts/build_and_push_images.sh
+++ b/scripts/build_and_push_images.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Post-provision hook
+#
+# Builds the backend and frontend container images remotely inside the
+# deployment's Azure Container Registry (ACR) using 'az acr build' (no local
+# Docker required) and then updates the container apps to run the freshly
+# built images.
+#
+# The required values are provided by azd as environment variables (they are
+# outputs of infra/main.bicep). When the script is run outside of an azd hook
+# the values are read back with 'azd env get-value'.
+# ---------------------------------------------------------------------------
+
+echo "==> Post-provision: building and pushing application images to ACR"
+
+# Ensure the Azure CLI is available and authenticated (az acr build / containerapp
+# update use the az CLI, which authenticates independently from azd).
+if ! command -v az >/dev/null 2>&1; then
+  echo "ERROR: Azure CLI ('az') is not installed. Install it from https://aka.ms/azcli" >&2
+  exit 1
+fi
+if ! az account show >/dev/null 2>&1; then
+  echo "ERROR: You are not signed in to the Azure CLI. Run 'az login' and retry." >&2
+  exit 1
+fi
+
+# Reads an environment variable, falling back to the azd environment.
+load_env_var() {
+  local name="$1"
+  local value="${!name:-}"
+  if [ -z "$value" ]; then
+    value=$(azd env get-value "$name" 2>/dev/null || true)
+  fi
+  printf '%s' "$value"
+}
+
+ACR_NAME=$(load_env_var AZURE_CONTAINER_REGISTRY_NAME)
+ACR_ENDPOINT=$(load_env_var AZURE_CONTAINER_REGISTRY_ENDPOINT)
+RESOURCE_GROUP=$(load_env_var AZURE_RESOURCE_GROUP)
+BACKEND_APP=$(load_env_var BACKEND_CONTAINER_APP_NAME)
+FRONTEND_APP=$(load_env_var FRONTEND_CONTAINER_APP_NAME)
+IMAGE_TAG=$(load_env_var AZURE_ENV_IMAGE_TAG)
+IMAGE_TAG=${IMAGE_TAG:-latest}
+
+# Derive the login server from the registry name if the output was not available.
+if [ -z "$ACR_ENDPOINT" ] && [ -n "$ACR_NAME" ]; then
+  ACR_ENDPOINT="${ACR_NAME}.azurecr.io"
+fi
+
+missing=""
+[ -z "$ACR_NAME" ] && missing="$missing AZURE_CONTAINER_REGISTRY_NAME"
+[ -z "$RESOURCE_GROUP" ] && missing="$missing AZURE_RESOURCE_GROUP"
+[ -z "$BACKEND_APP" ] && missing="$missing BACKEND_CONTAINER_APP_NAME"
+[ -z "$FRONTEND_APP" ] && missing="$missing FRONTEND_CONTAINER_APP_NAME"
+if [ -n "$missing" ]; then
+  echo "ERROR: Missing required environment values:$missing" >&2
+  exit 1
+fi
+
+# Resolve the repository root (this script lives in <repo>/scripts).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+BACKEND_IMAGE="cmsabackend:${IMAGE_TAG}"
+FRONTEND_IMAGE="cmsafrontend:${IMAGE_TAG}"
+
+# Ensure the Microsoft.App resource provider is registered before updating the
+# container apps. ARM registration can still be propagating after provisioning,
+# which makes 'az containerapp update' fail with a "not registered" error.
+echo "==> Ensuring the Microsoft.App resource provider is registered"
+az provider register --namespace Microsoft.App --wait
+
+echo "==> Building backend image ($BACKEND_IMAGE) in ACR '$ACR_NAME'"
+az acr build \
+  --registry "$ACR_NAME" \
+  --image "$BACKEND_IMAGE" \
+  --file "$REPO_ROOT/src/backend/Dockerfile" \
+  "$REPO_ROOT/src/backend"
+
+echo "==> Building frontend image ($FRONTEND_IMAGE) in ACR '$ACR_NAME'"
+az acr build \
+  --registry "$ACR_NAME" \
+  --image "$FRONTEND_IMAGE" \
+  --file "$REPO_ROOT/src/frontend/Dockerfile" \
+  "$REPO_ROOT/src/frontend"
+
+echo "==> Updating backend container app '$BACKEND_APP'"
+az containerapp update \
+  --name "$BACKEND_APP" \
+  --resource-group "$RESOURCE_GROUP" \
+  --image "${ACR_ENDPOINT}/${BACKEND_IMAGE}" \
+  --output none
+
+echo "==> Updating frontend container app '$FRONTEND_APP'"
+az containerapp update \
+  --name "$FRONTEND_APP" \
+  --resource-group "$RESOURCE_GROUP" \
+  --image "${ACR_ENDPOINT}/${FRONTEND_IMAGE}" \
+  --output none
+
+echo "==> Done. Container apps are now running the freshly built images."


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* This pull request introduces a major change to the deployment workflow by automating the build and deployment of backend and frontend container images using a provisioned Azure Container Registry (ACR). It also updates the default GPT model to `gpt-5.1` and refines several deployment parameters and documentation to reflect these changes. The most important changes are grouped below:

**Container Image Build and Deployment Automation**
* Added scripts (`build_and_push_images.sh` and `build_and_push_images.ps1`) to build backend and frontend images remotely in the deployment's ACR and update the container apps to use these images, eliminating the need for local Docker.
* Updated `infra/main.bicep` to provision a dedicated Azure Container Registry per deployment, configure container apps to use a placeholder image initially, and output relevant ACR and container app information for use by the post-provision scripts. [[1]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R897-R925) [[2]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R982-R992) [[3]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R1169-R1174) [[4]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L1148-R1188) [[5]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R1245-R1259)
* Removed parameters and references to a static container registry endpoint in parameter files, as each deployment now provisions its own registry. [[1]](diffhunk://#diff-834bc11e3cb55730076a7d70767b75f794dc9a37305f27d99926e0fd24363c13L26-L28) [[2]](diffhunk://#diff-f77c51c643b32c3e1047253afb8466b420d90485fb399eede5fb04ce6738b9b6L26-L28)

**Deployment and Documentation Updates**
* Updated the deployment guide (`docs/DeploymentGuide.md`) to include a new step for building and pushing container images, adjusted the expected deployment duration, and clarified the post-deployment workflow. [[1]](diffhunk://#diff-5a9feaaa3fe70489e88e08725db341b9dafb6a4185d382bba81c4093aaaded7cR283-R335) [[2]](diffhunk://#diff-5a9feaaa3fe70489e88e08725db341b9dafb6a4185d382bba81c4093aaaded7cL332-R349)
* Improved parameter documentation in `docs/CustomizingAzdParameters.md` to reflect the new image build process and updated descriptions for image and model parameters.

**Model Version and Parameter Updates**
* Changed the default GPT model from `gpt-4o` to `gpt-5.1` and updated the default version to `2025-11-13` in all relevant Bicep files and documentation. [[1]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L37-R37) [[2]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L101-R110) [[3]](diffhunk://#diff-6f5772bf1f1d80cc16f30c80915d9e5622ad0637daf5b5dff29308ad5fc68b62L37-R37) [[4]](diffhunk://#diff-6f5772bf1f1d80cc16f30c80915d9e5622ad0637daf5b5dff29308ad5fc68b62L101-R102) [[5]](diffhunk://#diff-6f5772bf1f1d80cc16f30c80915d9e5622ad0637daf5b5dff29308ad5fc68b62L114-R115)

**Minor and Maintenance Changes**
* Corrected CODEOWNERS usernames to reflect current team assignments.

These changes together streamline the deployment pipeline, ensure each deployment uses its own secure and isolated container registry, and update the project to use the latest available GPT model.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->

