### PR TITLE
fix: clarify deployment steps and expected duration in the Deployment Guide

### DIFF
--- a/docs/DeploymentGuide.md
+++ b/docs/DeploymentGuide.md
@@ -297,13 +297,13 @@ azd up
      .\scripts\build_and_push_images.ps1
      ```
 
-**During deployment, you'll be prompted for:**
+**During Step 4.2 (`azd up`), you'll be prompted for:**
 1. **Environment name** (e.g., "cmsaapp") - Must be 3-16 characters long, alphanumeric only
 2. **Azure subscription** selection
 3. **Azure region** - Select a region with available GPT model quota
 4. **Resource group** selection (create new or use existing)
 
-**Expected Duration:** 9-14 minutes for default configuration (includes remotely building and pushing the container images)
+**Expected Duration (Steps 4-5):** 9-14 minutes for default configuration (includes remotely building and pushing the container images)
 
 **⚠️ Deployment Issues:** If you encounter errors or timeouts, try a different region as there may be capacity constraints. For detailed error solutions, see our [Troubleshooting Guide](./TroubleShootingSteps.md).
 

--- a/docs/DeploymentGuide.md
+++ b/docs/DeploymentGuide.md
@@ -280,6 +280,16 @@ azd config set provision.preflight off
 azd up
 ```
 
+**During Step 4.2 (`azd up`), you'll be prompted for:**
+1. **Environment name** (e.g., "cmsaapp") - Must be 3-16 characters long, alphanumeric only
+2. **Azure subscription** selection
+3. **Azure region** - Select a region with available GPT model quota
+4. **Resource group** selection (create new or use existing)
+
+**Expected Duration (Steps 4-5):** 9-14 minutes for default configuration (includes remotely building and pushing the container images)
+
+**⚠️ Deployment Issues:** If you encounter errors or timeouts, try a different region as there may be capacity constraints. For detailed error solutions, see our [Troubleshooting Guide](./TroubleShootingSteps.md).
+
 ## Step 5: Build and Push Container Images
 ### 5.1 Run Image Build Script
  
@@ -296,16 +306,6 @@ azd up
      ```
      .\scripts\build_and_push_images.ps1
      ```
-
-**During Step 4.2 (`azd up`), you'll be prompted for:**
-1. **Environment name** (e.g., "cmsaapp") - Must be 3-16 characters long, alphanumeric only
-2. **Azure subscription** selection
-3. **Azure region** - Select a region with available GPT model quota
-4. **Resource group** selection (create new or use existing)
-
-**Expected Duration (Steps 4-5):** 9-14 minutes for default configuration (includes remotely building and pushing the container images)
-
-**⚠️ Deployment Issues:** If you encounter errors or timeouts, try a different region as there may be capacity constraints. For detailed error solutions, see our [Troubleshooting Guide](./TroubleShootingSteps.md).
 
 ### 5.2 Get Application URL
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This pull request makes small improvements to the deployment documentation by clarifying the prompts and expected duration during the `azd up` step.

- The heading describing prompts during deployment now specifically refers to "Step 4.2 (`azd up`)" for clarity.
- The expected duration note now references "Steps 4-5" to better indicate the relevant deployment steps.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.
