### PR TITLE
fix: Correct file paths in Dockerfile for backend requirements and code

### DIFF
--- a/docker/Backend.Dockerfile
+++ b/docker/Backend.Dockerfile
@@ -7,13 +7,13 @@ apt-get install -y libicu-dev
 WORKDIR /app
 
 # Copy only requirements first to leverage Docker cache
-COPY ../src/backend/requirements.txt .
+COPY src/backend/requirements.txt .
 
 # Install dependencies
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy backend code
-COPY ../src/backend/ .
+COPY src/backend/ .
 
 EXPOSE 8000
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This pull request updates the Docker build context for the backend service to use the correct relative paths when copying files into the Docker image. This ensures that the Docker build process works as expected when building from the repository root.

- Docker build context correction:
  * Updated the `COPY` commands in `docker/Backend.Dockerfile` to use `src/backend/requirements.txt` and `src/backend/` instead of `../src/backend/requirements.txt` and `../src/backend/`. This fixes file path issues during Docker image build.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.


