### PR TITLE
fix:  added post-deployment script/command visible in the terminal after deployment.

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -52,8 +52,10 @@ hooks:
         }
         
         Write-Host ""
+        $webAppUrl = $env:WEB_APP_URL
+        if ([string]::IsNullOrWhiteSpace($webAppUrl)) { $webAppUrl = azd env get-value WEB_APP_URL 2>$null }
         Write-Host "Web app URL: " -NoNewline
-        Write-Host "$env:WEB_APP_URL" -ForegroundColor Cyan
+        Write-Host "$webAppUrl" -ForegroundColor Cyan
       shell: pwsh
       continueOnError: false
       interactive: true
@@ -63,7 +65,9 @@ hooks:
         echo "=> Next step: build and push container images to the dedicated ACR (remote build):"
         echo "  bash scripts/build_and_push_images.sh"
         echo ""
-        echo "Web app URL: $WEB_APP_URL"
+        WEB_APP_URL_DISPLAY="$WEB_APP_URL"
+        if [ -z "$WEB_APP_URL_DISPLAY" ]; then WEB_APP_URL_DISPLAY=$(azd env get-value WEB_APP_URL 2>/dev/null); fi
+        echo "Web app URL: $WEB_APP_URL_DISPLAY"
       shell: sh
       continueOnError: false
       interactive: true

--- a/azure.yaml
+++ b/azure.yaml
@@ -46,9 +46,9 @@ hooks:
         
         # Check if running from bash/MINGW64 terminal
         if ($env:SHELL -like "*bash*" -or $env:TERM_PROGRAM -like "*git*" -or $env:MSYSTEM -eq "MINGW64") {
-          Write-Host "  bash ./scripts/build_and_push_images.sh" -ForegroundColor Cyan
+          Write-Host "  bash scripts/build_and_push_images.sh" -ForegroundColor Cyan
         } else {
-          Write-Host "  ./scripts/build_and_push_images.ps1" -ForegroundColor Cyan
+          Write-Host "  .\scripts\build_and_push_images.ps1" -ForegroundColor Cyan
         }
         
         Write-Host ""
@@ -61,7 +61,7 @@ hooks:
       run: |
         echo "===== Provisioning Complete ====="
         echo "=> Next step: build and push container images to the dedicated ACR (remote build):"
-        echo "  bash ./scripts/build_and_push_images.sh"
+        echo "  bash scripts/build_and_push_images.sh"
         echo ""
         echo "Web app URL: $WEB_APP_URL"
       shell: sh

--- a/azure.yaml
+++ b/azure.yaml
@@ -38,6 +38,35 @@ hooks:
         printf '\n'
       shell: sh
       interactive: true
+  postprovision:
+    windows:
+      run: |
+        Write-Host "===== Provisioning Complete =====" -ForegroundColor Green
+        Write-Host "=> Next step: build and push container images to the dedicated ACR (remote build):" -ForegroundColor Yellow
+        
+        # Check if running from bash/MINGW64 terminal
+        if ($env:SHELL -like "*bash*" -or $env:TERM_PROGRAM -like "*git*" -or $env:MSYSTEM -eq "MINGW64") {
+          Write-Host "  bash ./scripts/build_and_push_images.sh" -ForegroundColor Cyan
+        } else {
+          Write-Host "  ./scripts/build_and_push_images.ps1" -ForegroundColor Cyan
+        }
+        
+        Write-Host ""
+        Write-Host "Web app URL: " -NoNewline
+        Write-Host "$env:WEB_APP_URL" -ForegroundColor Cyan
+      shell: pwsh
+      continueOnError: false
+      interactive: true
+    posix:
+      run: |
+        echo "===== Provisioning Complete ====="
+        echo "=> Next step: build and push container images to the dedicated ACR (remote build):"
+        echo "  bash ./scripts/build_and_push_images.sh"
+        echo ""
+        echo "Web app URL: $WEB_APP_URL"
+      shell: sh
+      continueOnError: false
+      interactive: true
 deployment:
   mode: Incremental
   template: ./infra/main.bicep  # Path to the main.bicep file inside the 'deployment' folder


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This pull request adds a new `postprovision` hook to the `azure.yaml` configuration, enhancing the developer experience after provisioning is complete. The hook provides clear instructions for the next steps and displays the web app URL, with tailored messages for both Windows and POSIX environments.

**Enhancements to provisioning workflow:**

* Added a `postprovision` hook to `azure.yaml` that outputs a completion message, next-step instructions for building and pushing container images, and the web app URL after provisioning. The hook provides platform-specific guidance for both Windows (PowerShell) and POSIX (sh) environments.
## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.
